### PR TITLE
Refactor GoogleAIPlatformJob to initialize with a job_id

### DIFF
--- a/tests/unit/test_gcp_job.py
+++ b/tests/unit/test_gcp_job.py
@@ -5,6 +5,7 @@ from train.gcp_job import (
     GoogleAIPlatformJob,
     ModelDefn
 )
+from train import gcp_job
 
 
 def test_build_job_config_simple(monkeypatch):
@@ -175,87 +176,109 @@ def test_build_remote_data_fname_long(monkeypatch):
         'gs://mybucket/data/blah.jsonl'
 
 
-def test_get_job_status_v1():
-    job = GoogleAIPlatformJob({
-        "createTime": "2020-04-02T23:24:18Z",
-        "etag": "2TFzYuw9IIA=",
-        "jobId": "t_99e5cb31_8343_4ec3_8b5e_c6cdedfb7e3d_v_5",
-        "labels": {
-                "owner": "alchemy",
-                "type": "production",
-                "version": "1"
-        },
-        "startTime": "2020-04-02T23:27:09Z",
-        "state": "RUNNING",
-        "trainingInput": {
-            "args": [
-                "--dir",
-                "gs://_REDACTED_/tasks/8b5e-c6cdedfb7e3d/models/5",
-                "--infer",
-                "gs://_REDACTED_/data/spring_jan_2020.jsonl",
-                "gs://_REDACTED_/data/spring_feb_2020.jsonl",
-                "--eval-batch-size",
-                "16"
-            ],
-            "masterConfig": {
-                "acceleratorConfig": {
-                    "count": "1",
-                    "type": "NVIDIA_TESLA_P100"
-                },
-                "imageUri": "gcr.io/_REDACTED_"
+def test_get_job_status_v1(monkeypatch):
+    def mock_describe(job_id):
+        return {
+            "createTime": "2020-04-02T23:24:18Z",
+            "etag": "2TFzYuw9IIA=",
+            "jobId": "t_99e5cb31_8343_4ec3_8b5e_c6cdedfb7e3d_v_5",
+            "labels": {
+                    "owner": "alchemy",
+                    "type": "production",
+                    "version": "1"
             },
-            "masterType": "n1-standard-4",
-            "region": "us-central1",
-            "scaleTier": "CUSTOM"
-        },
-        "trainingOutput": {}
-    })
+            "startTime": "2020-04-02T23:27:09Z",
+            "state": "RUNNING",
+            "trainingInput": {
+                "args": [
+                    "--dir",
+                    "gs://_REDACTED_/tasks/8b5e-c6cdedfb7e3d/models/5",
+                    "--infer",
+                    "gs://_REDACTED_/data/spring_jan_2020.jsonl",
+                    "gs://_REDACTED_/data/spring_feb_2020.jsonl",
+                    "--eval-batch-size",
+                    "16"
+                ],
+                "masterConfig": {
+                    "acceleratorConfig": {
+                        "count": "1",
+                        "type": "NVIDIA_TESLA_P100"
+                    },
+                    "imageUri": "gcr.io/_REDACTED_"
+                },
+                "masterType": "n1-standard-4",
+                "region": "us-central1",
+                "scaleTier": "CUSTOM"
+            },
+            "trainingOutput": {}
+        }
+    monkeypatch.setattr(gcp_job, 'describe_ai_platform_job', mock_describe)
+
+    job = GoogleAIPlatformJob(123)
     assert job.get_state() == 'RUNNING'
     assert job.get_model_defns() == [ModelDefn('8b5e-c6cdedfb7e3d', '5')]
 
 
-def test_get_job_status_v2():
-    job = GoogleAIPlatformJob({
-        "createTime": "2020-04-02T23:24:18Z",
-        "etag": "2TFzYuw9IIA=",
-        "jobId": "t_99e5cb31_8343_4ec3_8b5e_c6cdedfb7e3d_v_5",
-        "labels": {
-                "owner": "alchemy",
-                "type": "production",
-                "version": "2"
-        },
-        "startTime": "2020-04-02T23:27:09Z",
-        "state": "RUNNING",
-        "trainingInput": {
-            "args": [
-                "--dirs",
-                "gs://_REDACTED_/tasks/8b5e-c6cdedfb7e3d/models/6",
-                "gs://_REDACTED_/tasks/8b5e-c6cdedfb7e3d/models/7",
-                "--infer",
-                "gs://_REDACTED_/data/spring_jan_2020.jsonl",
-                "gs://_REDACTED_/data/spring_feb_2020.jsonl",
-                "--eval-batch-size",
-                "16"
-            ],
-            "masterConfig": {
-                "acceleratorConfig": {
-                    "count": "1",
-                    "type": "NVIDIA_TESLA_P100"
-                },
-                "imageUri": "gcr.io/_REDACTED_"
+def test_get_job_status_v2(monkeypatch):
+    def mock_describe(job_id):
+        return {
+            "createTime": "2020-04-02T23:24:18Z",
+            "etag": "2TFzYuw9IIA=",
+            "jobId": "t_99e5cb31_8343_4ec3_8b5e_c6cdedfb7e3d_v_5",
+            "labels": {
+                    "owner": "alchemy",
+                    "type": "production",
+                    "version": "2"
             },
-            "masterType": "n1-standard-4",
-            "region": "us-central1",
-            "scaleTier": "CUSTOM"
-        },
-        "trainingOutput": {}
-    })
+            "startTime": "2020-04-02T23:27:09Z",
+            "state": "RUNNING",
+            "trainingInput": {
+                "args": [
+                    "--dirs",
+                    "gs://_REDACTED_/tasks/8b5e-c6cdedfb7e3d/models/6",
+                    "gs://_REDACTED_/tasks/8b5e-c6cdedfb7e3d/models/7",
+                    "--infer",
+                    "gs://_REDACTED_/data/spring_jan_2020.jsonl",
+                    "gs://_REDACTED_/data/spring_feb_2020.jsonl",
+                    "--eval-batch-size",
+                    "16"
+                ],
+                "masterConfig": {
+                    "acceleratorConfig": {
+                        "count": "1",
+                        "type": "NVIDIA_TESLA_P100"
+                    },
+                    "imageUri": "gcr.io/_REDACTED_"
+                },
+                "masterType": "n1-standard-4",
+                "region": "us-central1",
+                "scaleTier": "CUSTOM"
+            },
+            "trainingOutput": {}
+        }
+    monkeypatch.setattr(gcp_job, 'describe_ai_platform_job', mock_describe)
+
+    job = GoogleAIPlatformJob(123)
     assert job.get_state() == 'RUNNING'
     assert job.get_model_defns() == [ModelDefn('8b5e-c6cdedfb7e3d', '6'),
                                      ModelDefn('8b5e-c6cdedfb7e3d', '7')]
 
 
-def test_get_job_status_invalid():
+def test_get_job_status_invalid(monkeypatch):
+    def mock_describe(job_id):
+        return None
+    monkeypatch.setattr(gcp_job, 'describe_ai_platform_job', mock_describe)
+
+    job = GoogleAIPlatformJob(None)
+    assert job.get_state() is None
+    assert job.get_model_defns() == []
+
+
+def test_get_job_status_exception(monkeypatch):
+    def mock_describe(job_id):
+        raise Exception("Testing")
+    monkeypatch.setattr(gcp_job, 'describe_ai_platform_job', mock_describe)
+
     job = GoogleAIPlatformJob(None)
     assert job.get_state() is None
     assert job.get_model_defns() == []

--- a/train/gcp_celery.py
+++ b/train/gcp_celery.py
@@ -35,7 +35,7 @@ def poll_status(job_id: str, metadata_dict: Optional[dict] = None, poll_count: i
     """
     logging.info(f"Poll AI Platform job_id={job_id}, poll_count={poll_count}")
 
-    job = GoogleAIPlatformJob.fetch(job_id)
+    job = GoogleAIPlatformJob(job_id)
 
     if job is None:
         raise Exception("Unknown job")

--- a/train/gcp_job.py
+++ b/train/gcp_job.py
@@ -35,7 +35,7 @@ import uuid
 import re
 from collections import namedtuple
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 from db.utils import get_local_data_file_path
 from .paths import _get_version_dir
 from .no_deps.paths import (

--- a/train/gcp_job.py
+++ b/train/gcp_job.py
@@ -35,7 +35,7 @@ import uuid
 import re
 from collections import namedtuple
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from db.utils import get_local_data_file_path
 from .paths import _get_version_dir
 from .no_deps.paths import (
@@ -242,77 +242,36 @@ def submit_job(model_defns: List[ModelDefn],
 
 
 class GoogleAIPlatformJob:
-    def __init__(self, response: dict):
-        """
-        Note: Construct this via GoogleAIPlatformJob.fetch(job_id)
+    """Encapsulate an AI Platform job and provide some useful methods"""
 
-        Example response:
-        {
-            "createTime": "2020-04-02T23:24:18Z",
-            "etag": "2TFzYuw9IIA=",
-            "jobId": "t_99e5cb31_8343_4ec3_8b5e_c6cdedfb7e3d_v_5",
-            "labels": {
-                "owner": "alchemy",
-                "type": "production",
-                "version": "2"
-            },
-            "startTime": "2020-04-02T23:27:09Z",
-            "state": "RUNNING",
-            "trainingInput": {
-                "args": [
-                    "--dirs",
-                    "gs://_REDACTED_/tasks/99e5cb31-8343-4ec3-8b5e-c6cdedfb7e3d/models/6",
-                    "gs://_REDACTED_/tasks/99e5cb31-8343-4ec3-8b5e-c6cdedfb7e3d/models/7",
-                    "--infer",
-                    "gs://_REDACTED_/data/spring_jan_2020.jsonl",
-                    "gs://_REDACTED_/data/spring_feb_2020.jsonl",
-                    "--eval-batch-size",
-                    "16"
-                ],
-                "masterConfig": {
-                    "acceleratorConfig": {
-                        "count": "1",
-                        "type": "NVIDIA_TESLA_P100"
-                    },
-                    "imageUri": "gcr.io/_REDACTED_"
-                },
-                "masterType": "n1-standard-4",
-                "region": "us-central1",
-                "scaleTier": "CUSTOM"
-            },
-            "trainingOutput": {}
-        }
+    def __init__(self, job_id: str):
+        self.job_id = job_id
+        self.data_ = None
 
-        For all states, see:
-        https://cloud.google.com/ai-platform/training/docs/reference/rest/v1/projects.jobs#State
-        """
-        self.response = response or {}
-
-    @classmethod
-    def fetch(cls, job_id: str):
-        """This is the factory method to create GoogleAIPlatformJob objects"""
-        cmd = f"gcloud ai-platform jobs describe {job_id} --format json"
-
-        # TODO this is not best way to capture real error
-        # vs when a status doens't exist.
-        try:
-            res = run_cmd(cmd)
-        except Exception as e:
-            print(e)
-            return None
-        else:
-            return cls(json.loads(res.stdout))
+    def get_data(self) -> dict:
+        if self.data_ is None:
+            try:
+                self.data_ = describe_ai_platform_job(self.job_id)
+            except:
+                # If we run into an error, we'll retry on the next call.
+                pass
+        # If we ran into an error above, self.data_ would still be None.
+        # We want to always return a dict, so in the worst case we return {}.
+        return self.data_ or {}
 
     def get_state(self):
-        return self.response.get('state')
+        return self.get_data().get('state')
 
     def get_model_defns(self) -> List[ModelDefn]:
+        data = self.get_data()
+
         try:
-            training_args = self.response['trainingInput']['args']
+            training_args = data['trainingInput']['args']
         except KeyError:
-            # self.response['trainingInput']['args'] does not exist
+            # data['trainingInput']['args'] does not exist
             return []
         else:
+            # Parse the `training_args` str to find all the model directories.
             res = []
             in_region = False
 
@@ -342,17 +301,65 @@ class GoogleAIPlatformJob:
 
             return model_defns
 
-    def cancel(self) -> bool:
+    def cancel(self):
         """Cancel a running job
-        Returns True if the job was cancelled successfully
         Raises:
-            Exception if job_id is missing
             Exception if a job has already completed
         """
-        job_id = self.response.get("jobId")
-        assert job_id, "Cannot cancel job, missing job_id"
-        run_cmd(f'gcloud ai-platform jobs cancel {job_id}')
-        return True
+        cancel_ai_platform_job(self.job_id)
+
+
+def describe_ai_platform_job(job_id: str) -> dict:
+    """
+    Given a job_id of an AI Platform job, return information about the job.
+
+    Example response:
+    {
+        "createTime": "2020-04-02T23:24:18Z",
+        "etag": "2TFzYuw9IIA=",
+        "jobId": "t_99e5cb31_8343_4ec3_8b5e_c6cdedfb7e3d_v_5",
+        "labels": {
+            "owner": "alchemy",
+            "type": "production",
+            "version": "2"
+        },
+        "startTime": "2020-04-02T23:27:09Z",
+        "state": "RUNNING",
+        "trainingInput": {
+            "args": [
+                "--dirs",
+                "gs://_REDACTED_/tasks/99e5cb31-8343-4ec3-8b5e-c6cdedfb7e3d/models/6",
+                "gs://_REDACTED_/tasks/99e5cb31-8343-4ec3-8b5e-c6cdedfb7e3d/models/7",
+                "--infer",
+                "gs://_REDACTED_/data/spring_jan_2020.jsonl",
+                "gs://_REDACTED_/data/spring_feb_2020.jsonl",
+                "--eval-batch-size",
+                "16"
+            ],
+            "masterConfig": {
+                "acceleratorConfig": {
+                    "count": "1",
+                    "type": "NVIDIA_TESLA_P100"
+                },
+                "imageUri": "gcr.io/_REDACTED_"
+            },
+            "masterType": "n1-standard-4",
+            "region": "us-central1",
+            "scaleTier": "CUSTOM"
+        },
+        "trainingOutput": {}
+    }
+
+    For all states, see:
+    https://cloud.google.com/ai-platform/training/docs/reference/rest/v1/projects.jobs#State
+    """
+    cmd = f"gcloud ai-platform jobs describe {job_id} --format json"
+    res = run_cmd(cmd)
+    return json.loads(res.stdout)
+
+
+def cancel_ai_platform_job(job_id: str):
+    run_cmd(f'gcloud ai-platform jobs cancel {job_id}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `GoogleAIPlatformJob` used to be initialized with dict. This is quite confusing because you wouldn't know what to pass in, and it's error-prone. We can actually just initialize it with a `job_id` string instead.

Also refactored methods that call into the `gcloud ai-platform` cli into their own functions, so we can at a later time easily replace these with proper API calls.

NEXT: After this PR, there are some more cleanup to do in `train/gcp_job.py`