### PR TITLE
Introduce ModelStorageManager and DatasetStorageManager

### DIFF
--- a/db/fs.py
+++ b/db/fs.py
@@ -7,3 +7,10 @@ MODELS_DIR = 'models'
 
 def filestore_base_dir():
     return os.environ.get('ALCHEMY_FILESTORE_DIR', '__filestore')
+
+
+def raw_data_dir():
+    # TODO Refactor: Use this function in more places.
+    # If you search `RAW_DATA_DIR`, you'll find many duplicate instances of
+    # this function. Try to move them all into this file.
+    return os.path.join(filestore_base_dir(), RAW_DATA_DIR)

--- a/tests/integration/test_train_flow.py
+++ b/tests/integration/test_train_flow.py
@@ -204,7 +204,13 @@ def test_train_flow(dbsession, monkeypatch, tmp_path):
         {'text': 'newline_2'}
     ])
 
-    inference_cache = build_inference_cache(model_dir, [str(f)])
+    class Mock_DatasetStorageManager:
+        def download(self, url):
+            # Return the one data file we have locally.
+            return str(f)
+    mock_dsm = Mock_DatasetStorageManager()
+
+    inference_cache = build_inference_cache(model_dir, mock_dsm)
     model, _ = inference(model_dir, str(f2),
                          build_model_fn=stub_build_fn, generate_plots=False,
                          inference_cache=inference_cache)

--- a/tests/unit/test_gcp_job.py
+++ b/tests/unit/test_gcp_job.py
@@ -1,7 +1,5 @@
 from train.gcp_job import (
     build_job_config,
-    build_remote_model_dir,
-    build_remote_data_fname,
     GoogleAIPlatformJob,
     ModelDefn
 )
@@ -98,6 +96,7 @@ trainingInput:
     - "--infer"
     - gs://my_bucket/data/spring_jan_2020.jsonl
     - gs://my_bucket/data/spring_jan_2021.jsonl
+    - spring_jan_2022.jsonl
     - "--data-dir"
     - gs://gs://blah/data
     - "--eval-batch-size"
@@ -112,7 +111,9 @@ trainingInput:
 
     result = build_job_config(model_dirs=['gs://my_bucket/model_dir'],
                               files_for_inference=[
-                                  'gs://my_bucket/data/spring_jan_2020.jsonl', 'gs://my_bucket/data/spring_jan_2021.jsonl'],
+                                  'gs://my_bucket/data/spring_jan_2020.jsonl',
+                                  'gs://my_bucket/data/spring_jan_2021.jsonl',
+                                  'spring_jan_2022.jsonl'],
                               version='1')
 
     assert expected.strip() == result.strip()
@@ -156,24 +157,6 @@ trainingInput:
                               version='1')
 
     assert expected.strip() == result.strip()
-
-
-def test_build_remote_model_dir(monkeypatch):
-    monkeypatch.setenv('GOOGLE_AI_PLATFORM_BUCKET', 'mybucket')
-    assert build_remote_model_dir('abc', 2) == \
-        'gs://mybucket/tasks/abc/models/2'
-
-
-def test_build_remote_data_fname(monkeypatch):
-    monkeypatch.setenv('GOOGLE_AI_PLATFORM_BUCKET', 'mybucket')
-    assert build_remote_data_fname('blah.jsonl') == \
-        'gs://mybucket/data/blah.jsonl'
-
-
-def test_build_remote_data_fname_long(monkeypatch):
-    monkeypatch.setenv('GOOGLE_AI_PLATFORM_BUCKET', 'mybucket')
-    assert build_remote_data_fname('/tmp/foo/blah.jsonl') == \
-        'gs://mybucket/data/blah.jsonl'
 
 
 def test_get_job_status_v1(monkeypatch):

--- a/tests/unit/test_train_no_deps_paths.py
+++ b/tests/unit/test_train_no_deps_paths.py
@@ -1,10 +1,10 @@
 from train.no_deps.paths import (
-    _inference_fnames_to_original_fnames
+    _inference_fnames_to_datasets
 )
 
 
-def test__inference_fnames_to_original_fnames():
-    fnames = _inference_fnames_to_original_fnames([
+def test__inference_fnames_to_datasets():
+    fnames = _inference_fnames_to_datasets([
         'blah.pred.npy',
         'blah.blah.pred.npy',
         'invalid_file.txt',  # Invalid files are ignored

--- a/tests/unit/test_train_no_deps_paths.py
+++ b/tests/unit/test_train_no_deps_paths.py
@@ -4,14 +4,14 @@ from train.no_deps.paths import (
 
 
 def test__inference_fnames_to_datasets():
-    fnames = _inference_fnames_to_datasets([
+    datasets = _inference_fnames_to_datasets([
         'blah.pred.npy',
         'blah.blah.pred.npy',
         'invalid_file.txt',  # Invalid files are ignored
         '/home/dir/ok.pred.npy']
     )
 
-    assert fnames == [
+    assert datasets == [
         'blah.jsonl',
         'blah.blah.jsonl',
         'ok.jsonl'

--- a/train/gcp_celery.py
+++ b/train/gcp_celery.py
@@ -2,9 +2,8 @@ import logging
 import os
 from typing import Optional
 from celery import Celery
-from train.gcp_job import GoogleAIPlatformJob
+from train.gcp_job import GoogleAIPlatformJob, build_model_storage_manager
 from train.gs_utils import create_deployed_inference, DeployedInferenceMetadata
-from train.no_deps.storage_manager import get_model_storage_manager
 
 app = Celery(
     # module name
@@ -66,7 +65,7 @@ def poll_status(job_id: str, metadata_dict: Optional[dict] = None, poll_count: i
 def on_job_success(job: GoogleAIPlatformJob, metadata_dict: Optional[dict] = None):
     # Sync down the model assets
     for md in job.get_model_defns():
-        msm = get_model_storage_manager(md.uuid, md.version)
+        msm = build_model_storage_manager(md.uuid, md.version)
         msm.download(include_weights=False)
     # Deploy inferences to prod as needed
     if metadata_dict:

--- a/train/gcp_celery.py
+++ b/train/gcp_celery.py
@@ -2,8 +2,9 @@ import logging
 import os
 from typing import Optional
 from celery import Celery
-from train.gcp_job import GoogleAIPlatformJob, download
+from train.gcp_job import GoogleAIPlatformJob
 from train.gs_utils import create_deployed_inference, DeployedInferenceMetadata
+from train.no_deps.storage_manager import get_model_storage_manager
 
 app = Celery(
     # module name
@@ -65,7 +66,8 @@ def poll_status(job_id: str, metadata_dict: Optional[dict] = None, poll_count: i
 def on_job_success(job: GoogleAIPlatformJob, metadata_dict: Optional[dict] = None):
     # Sync down the model assets
     for md in job.get_model_defns():
-        download(md)
+        msm = get_model_storage_manager(md.uuid, md.version)
+        msm.download(include_weights=False)
     # Deploy inferences to prod as needed
     if metadata_dict:
         metadata = DeployedInferenceMetadata.from_dict(metadata_dict)

--- a/train/gcp_job.py
+++ b/train/gcp_job.py
@@ -126,13 +126,13 @@ class GoogleAIPlatformJob:
     """Encapsulate an AI Platform job and provide some useful methods"""
 
     def __init__(self, job_id: str):
-        self.job_id = job_id
+        self.id = job_id
         self.data_ = None
 
     def get_data(self) -> dict:
         if self.data_ is None:
             try:
-                self.data_ = describe_ai_platform_job(self.job_id)
+                self.data_ = describe_ai_platform_job(self.id)
             except:
                 # If we run into an error, we'll retry on the next call.
                 pass
@@ -185,11 +185,11 @@ class GoogleAIPlatformJob:
         Raises:
             Exception if a job has already completed
         """
-        cancel_ai_platform_job(self.job_id)
+        cancel_ai_platform_job(self.id)
 
 
 def submit_job(model_defns: List[ModelDefn],
-               datasets_for_inference: Optional[List[str]] = None,
+               files_for_inference: Optional[List[str]] = None,
                force_retrain: bool = False,
                submit_job_fn: callable = None) -> GoogleAIPlatformJob:
     """Submits a job and returns the corresponding GoogleAIPlatformJob."""
@@ -197,7 +197,7 @@ def submit_job(model_defns: List[ModelDefn],
 
     # Make sure each dataset is a file name, not a path.
     datasets_for_inference = [Path(dataset).name
-                              for dataset in datasets_for_inference]
+                              for dataset in files_for_inference]
 
     print("Upload model assets for training")
     gcs_model_dirs = []
@@ -221,7 +221,7 @@ def submit_job(model_defns: List[ModelDefn],
 
     model_config = build_job_config(
         model_dirs=gcs_model_dirs,
-        datasets_for_inference=datasets_for_inference)
+        files_for_inference=datasets_for_inference)
 
     with tempfile.NamedTemporaryFile(mode="w") as fp:
         fp.write(model_config)

--- a/train/gcp_job.py
+++ b/train/gcp_job.py
@@ -33,10 +33,10 @@ import json
 import tempfile
 import uuid
 import re
-import gs_url
 from collections import namedtuple
 from pathlib import Path
 from typing import List, Optional
+from train import gs_url
 from db.fs import raw_data_dir
 from .paths import _get_version_dir
 from .no_deps.utils import run_cmd
@@ -55,7 +55,7 @@ labels:
 trainingInput:
   scaleTier: CUSTOM
   masterType: n1-standard-4
-  args:{model_dirs}{datasets_for_inference}
+  args:{model_dirs}{files_for_inference}
     - "--data-dir"
     - {remote_data_dir}
     - "--eval-batch-size"
@@ -85,7 +85,7 @@ def __fmt_yaml_list(key, values: List[str], nspaces=0):
 
 def build_job_config(
         model_dirs: List[str],
-        datasets_for_inference: List[str] = None,
+        files_for_inference: List[str] = None,
         docker_image_uri: str = None,
         label_type: str = 'production',
         label_owner: str = 'alchemy',
@@ -94,7 +94,8 @@ def build_job_config(
     Inputs:
         model_dirs: The list of gs:// location of the models (Also known as the
             "version_dir" elsewhere in the codebase).
-        datasets_for_inference: A list of datasets we would like to run inference on.
+        files_for_inference: A list of datasets to run inference on, can
+            either be the dataset names OR their gs:// urls.
         docker_image_uri: The docker image URI. If None, will default to the
             env var GOOGLE_AI_PLATFORM_DOCKER_IMAGE_URI.
         label_type: Label for type.
@@ -109,11 +110,11 @@ def build_job_config(
     # Format lists into proper yaml.
     formatted_model_dirs = __fmt_yaml_list('dirs', model_dirs, nspaces=4)
     formatted_files_for_inference = __fmt_yaml_list(
-        'infer', datasets_for_inference, nspaces=4)
+        'infer', files_for_inference, nspaces=4)
 
     return JOB_CONFIG_TEMPLATE.format(
         model_dirs=formatted_model_dirs,
-        datasets_for_inference=formatted_files_for_inference,
+        files_for_inference=formatted_files_for_inference,
         remote_data_dir=gs_url.build_raw_data_dir(),
         docker_image_uri=docker_image_uri,
         label_type=label_type,

--- a/train/gcp_job.py
+++ b/train/gcp_job.py
@@ -114,7 +114,7 @@ def build_job_config(
     return JOB_CONFIG_TEMPLATE.format(
         model_dirs=formatted_model_dirs,
         datasets_for_inference=formatted_files_for_inference,
-        remote_data_dir=gs_url.build_data_dir_url(),
+        remote_data_dir=gs_url.build_raw_data_dir(),
         docker_image_uri=docker_image_uri,
         label_type=label_type,
         label_owner=label_owner,
@@ -191,10 +191,7 @@ def submit_job(model_defns: List[ModelDefn],
                datasets_for_inference: Optional[List[str]] = None,
                force_retrain: bool = False,
                submit_job_fn: callable = None) -> GoogleAIPlatformJob:
-    """
-    Returns:
-        The job id on Google AI Platform.
-    """
+    """Submits a job and returns the corresponding GoogleAIPlatformJob."""
     # TODO pass through the force_retrain parameter.
 
     # Make sure each dataset is a file name, not a path.
@@ -218,7 +215,7 @@ def submit_job(model_defns: List[ModelDefn],
         #       be uploading datasets.
         dsm.sync(dataset)
 
-    job_id = generate_job_id_()
+    job_id = __generate_job_id()
     print(f"Submit job: {job_id}")
 
     model_config = build_job_config(
@@ -236,7 +233,7 @@ def submit_job(model_defns: List[ModelDefn],
     return GoogleAIPlatformJob(job_id)
 
 
-def generate_job_id_():
+def __generate_job_id():
     # A valid job_id only contains letters, numbers and underscores,
     # AND must start with a letter.
     return 't_' + str(uuid.uuid4()).replace('-', '_')
@@ -251,7 +248,7 @@ def build_model_storage_manager(uuid, version) -> ModelStorageManager:
 
 def build_dataset_storage_manager() -> DatasetStorageManager:
     """Factory function"""
-    remote_data_dir = gs_url.build_data_dir_url()
+    remote_data_dir = gs_url.build_raw_data_dir()
     local_data_dir = raw_data_dir()
     return DatasetStorageManager(remote_data_dir, local_data_dir)
 

--- a/train/gcp_job.py
+++ b/train/gcp_job.py
@@ -33,19 +33,14 @@ import json
 import tempfile
 import uuid
 import re
+import gs_url
 from collections import namedtuple
 from pathlib import Path
 from typing import List, Optional
-from db.utils import get_local_data_file_path
+from db.fs import raw_data_dir
 from .paths import _get_version_dir
-from .no_deps.paths import (
-    _get_config_fname,
-    _get_exported_data_fname
-)
-from .no_deps.utils import (
-    gs_copy_file,
-    run_cmd
-)
+from .no_deps.utils import run_cmd
+from .no_deps.storage_manager import DatasetStorageManager, ModelStorageManager
 
 ModelDefn = namedtuple("ModelDefn", ("uuid", "version"))
 
@@ -60,7 +55,7 @@ labels:
 trainingInput:
   scaleTier: CUSTOM
   masterType: n1-standard-4
-  args:{model_dirs}{files_for_inference}
+  args:{model_dirs}{datasets_for_inference}
     - "--data-dir"
     - {remote_data_dir}
     - "--eval-batch-size"
@@ -74,7 +69,7 @@ trainingInput:
 '''
 
 
-def _fmt_yaml_list(key, values: List[str], nspaces=0):
+def __fmt_yaml_list(key, values: List[str], nspaces=0):
     """Spacing matters since we're constructing a yaml file. This function
     creates a string that represents a list of values in yaml."""
     result = ''
@@ -90,7 +85,7 @@ def _fmt_yaml_list(key, values: List[str], nspaces=0):
 
 def build_job_config(
         model_dirs: List[str],
-        files_for_inference: List[str] = None,
+        datasets_for_inference: List[str] = None,
         docker_image_uri: str = None,
         label_type: str = 'production',
         label_owner: str = 'alchemy',
@@ -99,7 +94,7 @@ def build_job_config(
     Inputs:
         model_dirs: The list of gs:// location of the models (Also known as the
             "version_dir" elsewhere in the codebase).
-        files_for_inference: A list of files we would like to run inference on.
+        datasets_for_inference: A list of datasets we would like to run inference on.
         docker_image_uri: The docker image URI. If None, will default to the
             env var GOOGLE_AI_PLATFORM_DOCKER_IMAGE_URI.
         label_type: Label for type.
@@ -111,134 +106,19 @@ def build_job_config(
             'GOOGLE_AI_PLATFORM_DOCKER_IMAGE_URI')
     assert docker_image_uri
 
-    # Note: Spacing matters since we're constructing a yaml file.
-    fmt_model_dirs = _fmt_yaml_list('dirs', model_dirs, nspaces=4)
-    fmt_files_for_inference = _fmt_yaml_list(
-        'infer', files_for_inference, nspaces=4)
+    # Format lists into proper yaml.
+    formatted_model_dirs = __fmt_yaml_list('dirs', model_dirs, nspaces=4)
+    formatted_files_for_inference = __fmt_yaml_list(
+        'infer', datasets_for_inference, nspaces=4)
 
-    bucket = os.environ.get('GOOGLE_AI_PLATFORM_BUCKET')
-    assert bucket, "Missing GOOGLE_AI_PLATFORM_BUCKET"
-    remote_data_dir = f'gs://{bucket}/data'
-
-    # TODO simple formatting like this is subject to injection attack.
     return JOB_CONFIG_TEMPLATE.format(
-        model_dirs=fmt_model_dirs,
-        files_for_inference=fmt_files_for_inference,
-        remote_data_dir=remote_data_dir,
+        model_dirs=formatted_model_dirs,
+        datasets_for_inference=formatted_files_for_inference,
+        remote_data_dir=gs_url.build_data_dir_url(),
         docker_image_uri=docker_image_uri,
         label_type=label_type,
         label_owner=label_owner,
         version=version)
-
-
-def build_remote_model_dir(model_uuid, model_version):
-    bucket = os.environ.get('GOOGLE_AI_PLATFORM_BUCKET')
-    assert bucket, "Missing GOOGLE_AI_PLATFORM_BUCKET"
-    # Legacy path system - let's not change it in fear of breaking things
-    return f'gs://{bucket}/tasks/{model_uuid}/models/{model_version}'
-
-
-def get_name(filename_or_path):
-    return Path(filename_or_path).name
-
-
-def build_remote_data_fname(data_filename):
-    """
-    Inputs:
-        data_filename: e.g. spring_jan_2020.jsonl
-    """
-    bucket = os.environ.get('GOOGLE_AI_PLATFORM_BUCKET')
-    assert bucket
-    return f'gs://{bucket}/data/{get_name(data_filename)}'
-
-
-def sync_data_file(fname):
-    local_fname = get_local_data_file_path(fname)
-    remote_fname = build_remote_data_fname(fname)
-    gs_copy_file(local_fname, remote_fname, no_clobber=True)
-    return remote_fname
-
-
-def prepare_model_assets_for_training(model_uuid, model_version):
-    # Training only needs the config and exported data.
-
-    version_dir = _get_version_dir(model_uuid, model_version)
-    config_fname = _get_config_fname(version_dir)
-    data_fname = _get_exported_data_fname(version_dir)
-
-    # We assume these two files exist
-    assert os.path.isfile(config_fname), \
-        f'Config File Not Found: {config_fname}'
-    assert os.path.isfile(data_fname), f'Data File Not Found: {data_fname}'
-
-    output_dir = build_remote_model_dir(model_uuid, model_version)
-
-    gs_copy_file(config_fname,
-                 os.path.join(output_dir, Path(config_fname).name))
-    gs_copy_file(data_fname,
-                 os.path.join(output_dir, Path(data_fname).name))
-
-    return output_dir
-
-
-def download(model: ModelDefn, include_weights=False):
-    """Download a model from cloud to local storage.
-    Args:
-        include_weights: If True, download the model weights as well.
-    """
-    src_dir = build_remote_model_dir(model.uuid, model.version)
-    dst_dir = _get_version_dir(model.uuid, model.version)
-    if include_weights:
-        run_cmd(f'gsutil -m rsync -r {src_dir} {dst_dir}')
-    else:
-        run_cmd(f'gsutil -m rsync -x "model" -r {src_dir} {dst_dir}')
-
-
-def submit_google_ai_platform_job(job_id, config_file):
-    run_cmd(f'gcloud ai-platform jobs submit training {job_id}'
-            f' --config {config_file}')
-
-
-def submit_job(model_defns: List[ModelDefn],
-               files_for_inference: Optional[List[str]] = None,
-               force_retrain=False,
-               submit_job_fn=None):
-    """
-    Returns:
-        The job id on Google AI Platform.
-    """
-    # TODO pass through the force_retrain parameter.
-
-    if submit_job_fn is None:
-        submit_job_fn = submit_google_ai_platform_job
-
-    # A valid job_id only contains letters, numbers and underscores
-    # AND must start with a letter.
-    job_id = 't_' + str(uuid.uuid4()).replace('-', '_')
-
-    print("Upload model assets for training, if needed")
-    model_dirs = [prepare_model_assets_for_training(md.uuid, md.version)
-                  for md in model_defns]
-
-    # Make sure the filenames are _names_, not _paths_
-    files_for_inference = files_for_inference or []
-    files_for_inference = [get_name(f) for f in files_for_inference]
-
-    print("Upload data for inference, if needed")
-    for fname in files_for_inference:
-        sync_data_file(fname)
-
-    print("Submit job")
-    with tempfile.NamedTemporaryFile(mode="w") as fp:
-        model_config = build_job_config(
-            model_dirs=model_dirs,
-            files_for_inference=files_for_inference)
-        fp.write(model_config)
-        fp.flush()
-
-        submit_job_fn(job_id, fp.name)
-
-    return job_id
 
 
 class GoogleAIPlatformJob:
@@ -263,12 +143,10 @@ class GoogleAIPlatformJob:
         return self.get_data().get('state')
 
     def get_model_defns(self) -> List[ModelDefn]:
-        data = self.get_data()
-
         try:
-            training_args = data['trainingInput']['args']
+            training_args = self.get_data()['trainingInput']['args']
         except KeyError:
-            # data['trainingInput']['args'] does not exist
+            # self.get_data()['trainingInput']['args'] does not exist
             return []
         else:
             # Parse the `training_args` str to find all the model directories.
@@ -307,6 +185,85 @@ class GoogleAIPlatformJob:
             Exception if a job has already completed
         """
         cancel_ai_platform_job(self.job_id)
+
+
+def submit_job(model_defns: List[ModelDefn],
+               datasets_for_inference: Optional[List[str]] = None,
+               force_retrain: bool = False,
+               submit_job_fn: callable = None) -> GoogleAIPlatformJob:
+    """
+    Returns:
+        The job id on Google AI Platform.
+    """
+    # TODO pass through the force_retrain parameter.
+
+    # Make sure each dataset is a file name, not a path.
+    datasets_for_inference = [Path(dataset).name
+                              for dataset in datasets_for_inference]
+
+    print("Upload model assets for training")
+    gcs_model_dirs = []
+    for md in model_defns:
+        msm = build_model_storage_manager(md.uuid, md.version)
+        msm.upload()
+        gcs_model_dirs.append(msm.remote_dir)
+
+    print("Sync data for inference")
+    dsm = build_dataset_storage_manager()
+    for dataset in datasets_for_inference:
+        # Ensure each dataset exists locally _and_ on GCS.
+        # TODO: We need datasets locally because later on we'll need it to
+        #       compute metrics, export inferences, etc. However, it's a bit
+        #       strange to download datasets here, when we really should only
+        #       be uploading datasets.
+        dsm.sync(dataset)
+
+    job_id = generate_job_id_()
+    print(f"Submit job: {job_id}")
+
+    model_config = build_job_config(
+        model_dirs=gcs_model_dirs,
+        datasets_for_inference=datasets_for_inference)
+
+    with tempfile.NamedTemporaryFile(mode="w") as fp:
+        fp.write(model_config)
+        fp.flush()
+
+        if submit_job_fn is None:
+            submit_job_fn = submit_ai_platform_job
+        submit_job_fn(job_id, fp.name)
+
+    return GoogleAIPlatformJob(job_id)
+
+
+def generate_job_id_():
+    # A valid job_id only contains letters, numbers and underscores,
+    # AND must start with a letter.
+    return 't_' + str(uuid.uuid4()).replace('-', '_')
+
+
+def build_model_storage_manager(uuid, version) -> ModelStorageManager:
+    """Factory function"""
+    remote_model_dir = gs_url.build_model_dir(uuid, version)
+    local_model_dir = _get_version_dir(uuid, version)
+    return ModelStorageManager(remote_model_dir, local_model_dir)
+
+
+def build_dataset_storage_manager() -> DatasetStorageManager:
+    """Factory function"""
+    remote_data_dir = gs_url.build_data_dir_url()
+    local_data_dir = raw_data_dir()
+    return DatasetStorageManager(remote_data_dir, local_data_dir)
+
+
+def submit_ai_platform_job(job_id, config_file):
+    """
+    Inputs:
+        job_id: The id of the new job.
+        config_file: Path to a config file on disk.
+    """
+    run_cmd(f'gcloud ai-platform jobs submit training {job_id}'
+            f' --config {config_file}')
 
 
 def describe_ai_platform_job(job_id: str) -> dict:

--- a/train/gs_url.py
+++ b/train/gs_url.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 
-def build_data_dir_url() -> str:
+def build_raw_data_dir() -> str:
     bucket = os.environ.get('GOOGLE_AI_PLATFORM_BUCKET')
     assert bucket, "GCS bucket not defined"
     return f"gs://{bucket}/data"
@@ -10,7 +10,7 @@ def build_data_dir_url() -> str:
 
 def build_raw_data_url(dataset_name) -> str:
     dataset_name_stem = Path(dataset_name).stem
-    return f"{build_data_dir_url()}/{dataset_name_stem}.jsonl"
+    return f"{build_raw_data_dir()}/{dataset_name_stem}.jsonl"
 
 
 def build_model_dir(model_uuid, model_version) -> str:

--- a/train/gs_url.py
+++ b/train/gs_url.py
@@ -2,18 +2,27 @@ import os
 from pathlib import Path
 
 
-def build_raw_data_url(dataset_name) -> str:
-    dataset_name_stem = Path(dataset_name).stem
+def build_data_dir_url() -> str:
     bucket = os.environ.get('GOOGLE_AI_PLATFORM_BUCKET')
     assert bucket, "GCS bucket not defined"
-    return f"gs://{bucket}/data/{dataset_name_stem}.jsonl"
+    return f"gs://{bucket}/data"
+
+
+def build_raw_data_url(dataset_name) -> str:
+    dataset_name_stem = Path(dataset_name).stem
+    return f"{build_data_dir_url()}/{dataset_name_stem}.jsonl"
+
+
+def build_model_dir(model_uuid, model_version) -> str:
+    bucket = os.environ.get('GOOGLE_AI_PLATFORM_BUCKET')
+    assert bucket, "GCS bucket not defined"
+    return f"gs://{bucket}/tasks/{model_uuid}/models/{model_version}"
 
 
 def build_model_inference_url(model_uuid, model_version, dataset_name) -> str:
     dataset_name_stem = Path(dataset_name).stem
-    bucket = os.environ.get('GOOGLE_AI_PLATFORM_BUCKET')
-    assert bucket, "GCS bucket not defined"
-    return f"gs://{bucket}/tasks/{model_uuid}/models/{model_version}/inference/{dataset_name_stem}.pred.npy"
+    model_dir = build_model_dir(model_uuid, model_version)
+    return f"{model_dir}/inference/{dataset_name_stem}.pred.npy"
 
 
 def _build_prod_dir(model_uuid, model_version, dataset_name, ts) -> str:

--- a/train/no_deps/paths.py
+++ b/train/no_deps/paths.py
@@ -1,6 +1,27 @@
 import os
 from pathlib import Path
 
+"""
+A model's directory consists of:
+- config.json : Model training and inference configurations.
+- data.jsonl : The original data from which the model was trained and the
+    evaluation metrics were calculated.
+- data_parser.json : (Not used often) A generated file that stores metadata
+    derived from `data.jsonl`, such as is the task binary or multi-class
+    classification.
+- metrics.json : A generated file storing the training and test metrics of the
+    model, created after a model has been successfully trained. Note we usually
+    don't use this file for metrics anymore, we comupte it on the fly using
+    db.model.Model.compute_metrics instead.
+- model/ : A directory of the actual model assets, e.g. weights, vocab, etc.
+- inference/ : Past inferences. Under this directory, you'll find:
+    - <dataset>.pred.npy : The raw inference file for `dataset`.
+        Use train.no_deps.inference_results.InferenceResults.load to view the
+        results.
+    - <dataset>.pred.<label_name>.histogram: A png of the histogram of positive
+        class probabilities for `label_name`.
+"""
+
 
 def _get_model_output_dir(version_dir):
     return os.path.join(version_dir, 'model')

--- a/train/no_deps/paths.py
+++ b/train/no_deps/paths.py
@@ -65,7 +65,7 @@ def _get_all_inference_fnames(version_dir):
     return res
 
 
-def _inference_fnames_to_original_fnames(fnames):
+def _inference_fnames_to_datasets(fnames):
     # Only retain files with the valid ending, and convert them to .jsonl
     ending = '.pred.npy'
 

--- a/train/no_deps/run.py
+++ b/train/no_deps/run.py
@@ -146,7 +146,7 @@ class InferenceCache:
         self.lookup_[self.hash(text)] = value
 
     def get(self, text):
-        self.lookup_.get(self.hash(text))
+        return self.lookup_.get(self.hash(text))
 
     def hash(self, text):
         # TODO choose some hash function

--- a/train/no_deps/run.py
+++ b/train/no_deps/run.py
@@ -12,8 +12,10 @@ from .paths import (
     _get_config_fname, _get_data_parser_fname,
     _get_exported_data_fname, _get_metrics_fname,
     _get_model_output_dir, _get_inference_fname,
-    _get_inference_density_plot_fname
+    _get_inference_density_plot_fname,
+    _get_all_inference_fnames, _inference_fnames_to_datasets
 )
+from .storage_manager import DatasetStorageManager
 from .transformers_textcat import train, evaluate_model, build_model
 from .inference_results import InferenceResults
 from .utils import (
@@ -126,73 +128,6 @@ def plot_results(version_dir, fname, inference_results) -> None:
         raise Exception("generate_plots only supports binary classification")
 
 
-def inference(version_dir, fname,
-              build_model_fn=None, generate_plots=True, inference_cache=None):
-    """
-    Inputs:
-        fname: A .jsonl file to run inference on.
-            Each line should contain a "text" key.
-
-    Results will be stored in version_dir/inference
-    """
-
-    model = load_model(version_dir, build_model_fn)
-
-    # Run Inference on fname
-    text = load_original_data_text(fname)
-    if inference_cache:
-        # If using the cache, we first pick out the elements not in cache
-        # and send those for inference.
-        to_infer = []
-        for t in text:
-            if inference_cache.get(t) is None:
-                to_infer.append(t)
-        _, raw = model.predict(to_infer)
-        # After we receive the results, update the cache.
-        for x, y in zip(to_infer, raw):
-            inference_cache[x] = y
-
-        # Finally, using the updated cache to populate all the raw results.
-        raw = []
-        for t in text:
-            # By now, all elements in text should have some results,
-            # so we can safely use [ ] to access.
-            raw.append(inference_cache[t])
-    else:
-        # If not using the cache, we just predict on all text.
-        _, raw = model.predict(text)
-        to_infer = text
-
-    inference_results = InferenceResults(raw)
-
-    # Make sure the output dir exists and save it
-    inference_results.save(_get_inference_fname(version_dir, fname))
-
-    # Generate Plots
-    if generate_plots:
-        plot_results(version_dir, fname, inference_results)
-
-    return model, inference_results
-
-
-def build_inference_cache(version_dir, fnames):
-    """Build an inference cache from the previous inference results by the
-    model in version_dir on the files in fnames.
-    """
-    lookup = {}
-
-    for fname in fnames:
-        text = load_original_data_text(fname)
-        inf = InferenceResults.load(_get_inference_fname(version_dir, fname))
-
-        if text and inf:
-            for x, y in zip(text, inf.raw):
-                if x:
-                    lookup[x] = y
-
-    return lookup
-
-
 def _plot(outname, data, title):
     import seaborn as sns
     import matplotlib.pyplot as plt
@@ -201,3 +136,92 @@ def _plot(outname, data, title):
     plt.title(title)
     sns_plot.figure.savefig(outname)
     plt.clf()
+
+
+class InferenceCache:
+    def __init__(self):
+        self.lookup_ = {}
+
+    def set(self, text, value):
+        self.lookup_[self.hash(text)] = value
+
+    def get(self, text):
+        self.lookup_.get(self.hash(text))
+
+    def hash(self, text):
+        # TODO choose some hash function
+        return text
+
+
+def build_inference_cache(version_dir: str,
+                          dsm: DatasetStorageManager) -> InferenceCache:
+    """Build an inference cache from the previous inference results by the
+    model in version_dir on the files in fnames.
+    """
+    cache = InferenceCache()
+
+    prev_inf_fnames = _get_all_inference_fnames(version_dir)
+    prev_inf_datasets = _inference_fnames_to_datasets(prev_inf_fnames)
+
+    for dataset in prev_inf_datasets:
+        dataset_path = dsm.download(dataset)
+        text = load_original_data_text(dataset_path)
+        inf = InferenceResults.load(
+            _get_inference_fname(version_dir, dataset_path))
+
+        if text and inf:
+            for x, y in zip(text, inf.raw):
+                if x:  # Ignore cases when the text is empty.
+                    cache.set(x, y)
+
+    return cache
+
+
+def inference(version_dir, dataset_local_path,
+              build_model_fn=None, generate_plots=True,
+              inference_cache: InferenceCache = None):
+    """
+    Inputs:
+        dataset_local_path: A .jsonl file to run inference on.
+            Each line should contain a "text" key.
+
+    Results will be stored in version_dir/inference
+    """
+
+    model = load_model(version_dir, build_model_fn)
+
+    # Run Inference on dataset
+    text = load_original_data_text(dataset_local_path)
+    if inference_cache:
+        # If using the cache, we first pick out the elements not in cache
+        # and send those for inference in batch.
+        to_infer = []
+        for t in text:
+            if inference_cache.get(t) is None:
+                to_infer.append(t)
+        _, raw = model.predict(to_infer)
+        # After we receive the results, update the cache.
+        for x, y in zip(to_infer, raw):
+            inference_cache.set(x, y)
+
+        # Finally, using the updated cache to populate all the raw results.
+        raw = []
+        for t in text:
+            # By now, all elements in text should have some results,
+            # so we can safely use [ ] to access.
+            raw.append(inference_cache.get(t))
+    else:
+        # If not using the cache, we just predict on all text.
+        _, raw = model.predict(text)
+
+    inference_results = InferenceResults(raw)
+
+    # Make sure the output dir exists and save it
+    inference_results.save(_get_inference_fname(
+        version_dir, dataset_local_path))
+
+    # Generate Plots
+    if generate_plots:
+        plot_results(version_dir, dataset_local_path, inference_results)
+
+    return model, inference_results

--- a/train/no_deps/storage_manager.py
+++ b/train/no_deps/storage_manager.py
@@ -6,13 +6,21 @@ from .utils import run_cmd, gs_copy_file
 class ModelStorageManager:
     """A logical interface to a model's assets. A ModelStorageManager instance
     provides methods to work with a local version of the model's assets and its
-    remote counterpart on GCS."""
+    remote counterpart on GCS.
+
+    Note: As of the current version, the ModelStorageManager does not know what
+    is inside the model directory; it simply syncs the entire directory between
+    a local dir and a remote dir. In future versions, we may consider giving
+    ModelStorageManager more responsibilities.
+
+    To see what's inside a model's directory, see paths.py
+    """
 
     def __init__(self, remote_model_dir: str, local_model_dir: str):
         """
         Inputs:
-            gcs_bucket: The bucket (or prefix) on GCS to store model files and
-                datasets. e.g. "alchemy". Note it does not include "gs://".
+            remote_model_dir: A gs:// url; the model's location on GCS.
+            local_model_dir: Path to the model's local directory.
         """
         self.remote_dir = remote_model_dir
         self.local_dir = local_model_dir
@@ -39,6 +47,11 @@ class DatasetStorageManager:
     with datasets"""
 
     def __init__(self, remote_data_dir, local_data_dir):
+        """
+        Inputs:
+            remote_data_dir: A gs:// url; the raw dataset dir on GCS.
+            local_data_dir: Path to the local directory that stores datasets.
+        """
         self.remote_dir = remote_data_dir
         self.local_dir = local_data_dir
 

--- a/train/no_deps/storage_manager.py
+++ b/train/no_deps/storage_manager.py
@@ -67,3 +67,5 @@ class DatasetStorageManager:
         local_path = f"{self.local_dir}/{dataset}"
 
         gs_copy_file(remote_path, local_path, no_clobber=True)
+
+        return local_path

--- a/train/no_deps/storage_manager.py
+++ b/train/no_deps/storage_manager.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
-from .utils import run_cmd
-from train.no_deps.utils import gs_copy_file
+from .utils import run_cmd, gs_copy_file
 
 
 class ModelStorageManager:

--- a/train/no_deps/storage_manager.py
+++ b/train/no_deps/storage_manager.py
@@ -1,0 +1,69 @@
+import os
+from pathlib import Path
+from .utils import run_cmd
+from train.no_deps.utils import gs_copy_file
+
+
+class ModelStorageManager:
+    """A logical interface to a model's assets. A ModelStorageManager instance
+    provides methods to work with a local version of the model's assets and its
+    remote counterpart on GCS."""
+
+    def __init__(self, remote_model_dir: str, local_model_dir: str):
+        """
+        Inputs:
+            gcs_bucket: The bucket (or prefix) on GCS to store model files and
+                datasets. e.g. "alchemy". Note it does not include "gs://".
+        """
+        self.remote_dir = remote_model_dir
+        self.local_dir = local_model_dir
+
+    def upload(self):
+        """Upload the entire model folder, only contents that have changed"""
+        run_cmd(f'gsutil -m rsync -r {self.local_dir} {self.remote_dir}')
+
+    def download(self, include_weights=True):
+        """Download a model from cloud to local storage.
+        Args:
+            include_weights: If True, download the model weights as well.
+        """
+        src = self.remote_dir
+        dst = self.local_dir
+        if include_weights:
+            run_cmd(f'gsutil -m rsync -r {src} {dst}')
+        else:
+            run_cmd(f'gsutil -m rsync -x "model" -r {src} {dst}')
+
+
+class DatasetStorageManager:
+    """Similar in principle to the ModelStorageManager, but this is for dealing
+    with datasets"""
+
+    def __init__(self, remote_data_dir, local_data_dir):
+        self.remote_dir = remote_data_dir
+        self.local_dir = local_data_dir
+
+    def sync(self, dataset):
+        """If the dataset exists at least either locally or remotely, this
+        method makes sure the dataset exists in both places."""
+        # Make sure dataset is a file name, not a path.
+        dataset = Path(dataset).name
+
+        remote_path = f"{self.remote_dir}/{dataset}"
+        local_path = f"{self.local_dir}/{dataset}"
+
+        # Sync; Attempt download, then attempt upload.
+        gs_copy_file(remote_path, local_path, no_clobber=True)
+        gs_copy_file(local_path, remote_path, no_clobber=True)
+
+        # Make sure it exists locally.
+        assert os.path.isfile(local_path), f'Missing dataset: {local_path}'
+
+    def download(self, dataset):
+        # Make sure dataset is a file name, not a path.
+        dataset = Path(dataset).name
+
+        remote_path = f"{self.remote_dir}/{dataset}"
+        local_path = f"{self.local_dir}/{dataset}"
+
+        gs_copy_file(remote_path, local_path, no_clobber=True)

--- a/train/train_celery.py
+++ b/train/train_celery.py
@@ -37,7 +37,7 @@ def submit_gcp_training(label, raw_file_path, entity_type):
 
         model_defn = ModelDefn(model.uuid, model.version)
         job = submit_job(model_defns=[model_defn],
-                         datasets_for_inference=[raw_file_path])
+                         files_for_inference=[raw_file_path])
         gcp_poll_status.delay(job.id)
     finally:
         db.session.close()
@@ -74,7 +74,7 @@ def submit_gcp_inference_on_new_file(dataset_name):
                 # Kick off a new job to run inference, then deploy when done.
                 model_defn = ModelDefn(model.uuid, model.version)
                 job = submit_job(model_defns=[model_defn],
-                                 datasets_for_inference=[dataset_name])
+                                 files_for_inference=[dataset_name])
                 gcp_poll_status.delay(job.id, metadata_dict=metadata.to_dict())
     finally:
         db.session.close()


### PR DESCRIPTION
A lot of indirection and duplicate code exist to handle moving _model data_ and _raw datasets_ to and from GCS. In this change, we introduce `ModelStorageManager` and `DatasetStorageManager` under `storage_manager.py` to handle the movement of data. Each StorageManager has conceptually a "local" directory (either on the server, or on the AI Platform), and a "remote" directory (on GCS). They expose interfaces like "download" and "upload". Elsewhere -- in submitting a new AI Platform job, and in starting training within an AI Platform job -- we can use these StorageManagers to simplify a lot of the code.

This also introduces some changes that renames `fname` to either `dataset` or `path`, where appropriate. The definition of a `dataset` is the filename with `.jsonl` ending, e.g. `data.jsonl`. A `path` is the file path, e.g. `/home/user/data.jsonl`. In the codebase, `fname` is loosely defined and sometimes can be either a `dataset` or a `path`, and is a source of confusion and unnecessary code. This PR addresses some of the cases where it's relevant, but not all.

TODO:
- [x] Fix tests
- [x] Run a manual test