### PR TITLE
Addressing the security alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ murmurhash==1.0.2
 numpy==1.19.1
 packaging==20.4
 pandas==1.1.1
-Pillow==6.1.0
+Pillow==7.1.0
 plac==1.1.3
 pluggy==0.13.1
 preshed==3.0.2


### PR DESCRIPTION
Just to address the security alert from github on the dependency `pillow` as suggested. https://github.com/georgianpartners/annotation_tool/network/alert/requirements.txt/pillow/open