### PR TITLE
Updated build file to use TARGET for being able to build multiple images 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim as alchemy-base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	 build-essential \
@@ -9,12 +9,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /base
 
-ARG TARGET=production
 COPY requirements ./requirements
-RUN pip install -r requirements/$TARGET.txt
+RUN pip install -r requirements/base.txt
 
 COPY ci ./ci
 RUN sh ci/install_deps.sh
 
 # Path configuration
 ENV PATH $PATH:/root/tools/google-cloud-sdk/bin
+
+FROM alchemy-base as local
+RUN pip install -r requirements/local.txt
+WORKDIR /app
+
+
+FROM alchemy-base as alchemy-with-code
+WORKDIR /app
+COPY . .
+
+FROM alchemy-with-code as production
+RUN pip install -r requirements/production.txt
+
+FROM alchemy-with-code as test
+RUN pip install -r requirements/test.txt

--- a/alchemy.Dockerfile
+++ b/alchemy.Dockerfile
@@ -1,5 +1,0 @@
-FROM alchemy-base
-
-WORKDIR /app
-
-COPY . .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,36 +1,55 @@
 steps:
-# Step1: Build the alchemy development image
-# that does not include the source codes as
-# the base
+# Build the alchemy test image
 #
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build',
-         '--tag', 'alchemy-base:$SHORT_SHA',
+         '--build-arg', 'TARGET=test',
+         '--tag', 'alchemy-base',
          '--file', 'Dockerfile',
          '.']
-  id: 'step-build-base'
-
-# Step2: Build the production image by copying
-# the source code into the image
-#
+  id: 'build-test-image-base'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build',
-         '--tag', 'gcr.io/$PROJECT_ID/alchemy:$SHORT_SHA',
+         '--build-arg', 'TARGET=test',
+         '--tag', 'gcr.io/$PROJECT_ID/alchemy:test-${SHORT_SHA}',
          '--file', 'alchemy.Dockerfile',
          '.']
-  wait_for: ['step-build-base']
-  id: 'step-build-prod'
+  wait_for: ['build-test-image-base']
+  id: 'build-test-image-full'
 
-# Step3: Run the tests
+# Run the tests, to prevent having broken
+# images. May look unnecessary since there are
+# GitHub actions that run tests, however it
+# wouldn't hurt to double check.
 #
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run',
          '--env', 'GOOGLE_AI_PLATFORM_ENABLED=0',
          '--env', 'USE_CLOUD_LOGGING=0',
-         'gcr.io/$PROJECT_ID/alchemy:$SHORT_SHA',
+         'gcr.io/$PROJECT_ID/alchemy:test-${SHORT_SHA}',
          'sh', 'ci/run_tests.sh']
-  wait_for: ['step-build-prod']
-  id: 'step-test'
-timeout: 600s
+  wait_for: ['build-test-image-full']
+  id: 'run-tests'
+
+# Build the target image
+#
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build',
+         '--build-arg', 'TARGET=${_TARGET}',
+         '--tag', 'alchemy-base',
+         '--file', 'Dockerfile',
+         '.']
+  wait_for: ['run-tests']
+  id: 'build-target-image-base'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build',
+         '--build-arg', 'TARGET=${_TARGET}',
+         '--tag', 'gcr.io/$PROJECT_ID/alchemy:${_TARGET}-${SHORT_SHA}',
+         '--file', 'alchemy.Dockerfile',
+         '.']
+  wait_for: ['build-target-image-base']
+  id: 'build-target-image-full'
+
+timeout: 1200s
 images:
-  - 'gcr.io/$PROJECT_ID/alchemy:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/alchemy:${_TARGET}-${SHORT_SHA}'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,19 +3,10 @@ steps:
 #
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build',
-         '--build-arg', 'TARGET=test',
-         '--tag', 'alchemy-base',
-         '--file', 'Dockerfile',
-         '.']
-  id: 'build-test-image-base'
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build',
-         '--build-arg', 'TARGET=test',
+         '--target', 'test',
          '--tag', 'gcr.io/$PROJECT_ID/alchemy:test-${SHORT_SHA}',
-         '--file', 'alchemy.Dockerfile',
          '.']
-  wait_for: ['build-test-image-base']
-  id: 'build-test-image-full'
+  id: 'build-test-image'
 
 # Run the tests, to prevent having broken
 # images. May look unnecessary since there are
@@ -28,27 +19,19 @@ steps:
          '--env', 'USE_CLOUD_LOGGING=0',
          'gcr.io/$PROJECT_ID/alchemy:test-${SHORT_SHA}',
          'sh', 'ci/run_tests.sh']
-  wait_for: ['build-test-image-full']
+  wait_for: ['build-test-image']
   id: 'run-tests'
 
 # Build the target image
 #
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build',
-         '--build-arg', 'TARGET=${_TARGET}',
-         '--tag', 'alchemy-base',
-         '--file', 'Dockerfile',
+         '--target', '${_TARGET}',
+         '--cache-from', 'gcr.io/$PROJECT_ID/alchemy:test-${SHORT_SHA}',
+         '--tag', 'gcr.io/$PROJECT_ID/alchemy:${_TARGET}-${SHORT_SHA}',
          '.']
   wait_for: ['run-tests']
-  id: 'build-target-image-base'
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build',
-         '--build-arg', 'TARGET=${_TARGET}',
-         '--tag', 'gcr.io/$PROJECT_ID/alchemy:${_TARGET}-${SHORT_SHA}',
-         '--file', 'alchemy.Dockerfile',
-         '.']
-  wait_for: ['build-target-image-base']
-  id: 'build-target-image-full'
+  id: 'build-target-image'
 
 timeout: 1200s
 images:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     env_file: .env
     build:
       context: .
-      dockerfile: alchemy.Dockerfile
+      dockerfile: Dockerfile
+      target: local
     image: &img alchemy
     ports:
       - "5000:5000"


### PR DESCRIPTION
Fixes: CU-epv2kw 

Updates:
1. It now builds a testing image and run tests on that
2. After tests pass, it will build the target image
3. Image tags now include the target as well. e.g. `test-62ba7cc`, `production-a335237`, `staging-172b61c`, etc.