### PR TITLE
Fixing the python import problem without using the sys path hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,17 @@ RUN sh ci/install_deps.sh
 
 # Path configuration
 ENV PATH $PATH:/root/tools/google-cloud-sdk/bin
+# This is necessary for the alembic migration to work
+ENV PYTHONPATH /app
 
 FROM alchemy-base as local
 RUN pip install -r requirements/local.txt
 WORKDIR /app
-ENV PYTHONPATH /app
 
 
 FROM alchemy-base as alchemy-with-code
 WORKDIR /app
 COPY . .
-ENV PYTHONPATH /app
 
 FROM alchemy-with-code as production
 RUN pip install -r requirements/production.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,13 @@ ENV PATH $PATH:/root/tools/google-cloud-sdk/bin
 FROM alchemy-base as local
 RUN pip install -r requirements/local.txt
 WORKDIR /app
+ENV PYTHONPATH /app
 
 
 FROM alchemy-base as alchemy-with-code
 WORKDIR /app
 COPY . .
+ENV PYTHONPATH /app
 
 FROM alchemy-with-code as production
 RUN pip install -r requirements/production.txt

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,6 +1,4 @@
 import logging
-import os
-import sys
 from envparse import env
 from logging.config import fileConfig
 
@@ -13,7 +11,6 @@ from sqlalchemy import engine_from_config, pool
 from alchemy.db.model import metadata
 from alembic import context
 
-sys.path = ["", ".."] + sys.path[1:]
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
One of the precommit-hook changed the order of some import statement in the `alembic` tool. This messed up the code since the code was using the `sys.path = ["", ".."] + sys.path[1:]` hack to find a module in a different directory. This is not  ideal. 

According to [this stackoverflow post](https://stackoverflow.com/questions/49039436/how-to-import-a-module-from-a-different-folder), we can solve the import path issue by setting the PYTHONPATH to the root folder and hence the change here. 

All tests pass and the migration scripts work too.