### PR TITLE
Guard against duplicate labels when a Task object is created. 

### DIFF
--- a/alchemy/admin_server/tasks.py
+++ b/alchemy/admin_server/tasks.py
@@ -105,7 +105,6 @@ def create():
         annotators = parse_annotators(form)
         data_files = parse_data(form, data_fnames)
 
-        print("Before creating the request!")
         create_request = TaskCreateRequest.from_dict(
             {
                 "name": name,

--- a/alchemy/admin_server/tasks.py
+++ b/alchemy/admin_server/tasks.py
@@ -115,18 +115,8 @@ def create():
                 "data_files": data_files,
             }
         )
-        print(create_request)
-        logging.info(create_request)
         task = task_dao.create_task(create_request=create_request)
 
-        # task = Task(name=name)
-        # task.set_labels(labels)
-        # task.set_annotators(annotators)
-        # task.set_data_filenames(data_files)
-        # task.set_entity_type(entity_type)
-        #
-        # db.session.add(task)
-        # db.session.commit()
         return redirect(url_for("tasks.show", id=task.id))
     except Exception as e:
         db.session.rollback()

--- a/alchemy/dao/annotation_dao.py
+++ b/alchemy/dao/annotation_dao.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from sqlalchemy.exc import DatabaseError, DBAPIError
+from sqlalchemy.exc import DBAPIError
 
 from alchemy.data.request.annotation_request import AnnotationUpsertRequest
 from alchemy.db.model import ClassificationAnnotation

--- a/alchemy/dao/task_dao.py
+++ b/alchemy/dao/task_dao.py
@@ -1,0 +1,73 @@
+from sqlalchemy.exc import DBAPIError
+from tenacity import (
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+    retry,
+)
+
+from alchemy.db.model import Task
+
+
+class TaskDao:
+    def __init__(self, dbsession):
+        self.dbsession = dbsession
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=6),
+        retry=retry_if_exception_type(DBAPIError),
+        reraise=True,
+    )
+    def create_task(self, create_request):
+        if not create_request:
+            raise Exception(f"Invalid request: {create_request.errors}")
+
+        labels = list(set(create_request.labels))
+
+        self._check_duplicate_labels(labels)
+
+        annotators = list(set(create_request.annotators))
+        task = Task(name=create_request.name)
+        task.set_labels(labels)
+        task.set_annotators(annotators)
+        task.set_data_filenames(create_request.data_files)
+        task.set_entity_type(create_request.entity_type)
+
+        self.dbsession.add(task)
+        self._commit_to_db()
+        return task
+
+    def _check_duplicate_labels(self, new_labels):
+        """This is a temporary hacky solution to prevent users from creating
+        duplicate labels. The proper solution involves a much bigger
+        refactoring.
+
+        Given the amount of tasks and labels we have, the performance is still
+        acceptable.
+
+        TODO replace this once we have the Market Management System in place.
+        """
+        tasks = self.dbsession.query(Task).all()
+
+        existing_labels = dict()
+        for task in tasks:
+            labels_in_task = task.get_labels()
+            for label in labels_in_task:
+                existing_labels[label] = task.name
+        error_msgs = []
+        for new_label in new_labels:
+            if new_label in existing_labels:
+                error_msgs.append(
+                    f"Label {new_label} is already created "
+                    f"in task {existing_labels[new_label]}"
+                )
+
+        raise Exception(error_msgs)
+
+    def _commit_to_db(self):
+        try:
+            self.dbsession.commit()
+        except Exception:
+            self.dbsession.rollback()
+            raise

--- a/alchemy/dao/task_dao.py
+++ b/alchemy/dao/task_dao.py
@@ -21,6 +21,8 @@ class TaskDao:
     )
     def create_task(self, create_request):
         if not create_request:
+            # TODO We should consider adding Response Object in pair with the
+            #  Request Object.
             raise Exception(f"Invalid request: {create_request.errors}")
 
         labels = list(set(create_request.labels))
@@ -62,8 +64,8 @@ class TaskDao:
                     f"Label {new_label} is already created "
                     f"in task {existing_labels[new_label]}"
                 )
-
-        raise Exception(error_msgs)
+        if len(error_msgs) > 0:
+            raise Exception(error_msgs)
 
     def _commit_to_db(self):
         try:

--- a/alchemy/data/request/annotation_request.py
+++ b/alchemy/data/request/annotation_request.py
@@ -1,6 +1,10 @@
-from dataclasses import dataclass, fields, asdict
+from dataclasses import dataclass, fields
 
-from alchemy.data.request.base_request import ValidRequest, InvalidRequest
+from alchemy.data.request.base_request import (
+    ValidRequest,
+    InvalidRequest,
+    validate_request_data_common,
+)
 
 
 @dataclass
@@ -25,21 +29,7 @@ class AnnotationUpsertRequest(ValidRequest):
 
     @classmethod
     def _validate_request_data(cls, dict_data, invalid_req):
-        for field in fields(cls):
-            if field.name not in dict_data:
-                invalid_req.add_error(
-                    parameter="dict_data", message=f"Missing field {field.name}."
-                )
-            elif not isinstance(dict_data[field.name], field.type):
-                invalid_req.add_error(
-                    parameter="dict_data",
-                    message=f"Field {field.name} expects {field.type} "
-                    f"but received {type(dict_data[field.name])}",
-                )
-
-        field_names = set([field.name for field in fields(cls)])
-        for key in dict_data:
-            if key not in field_names:
-                invalid_req.add_error(
-                    parameter="dict_data", message=f"Invalid field {key}."
-                )
+        data_fields = fields(cls)
+        validate_request_data_common(
+            fields=data_fields, dict_data=dict_data, invalid_req=invalid_req
+        )

--- a/alchemy/data/request/base_request.py
+++ b/alchemy/data/request/base_request.py
@@ -1,3 +1,7 @@
+from dataclasses import Field
+from typing import List, Dict
+
+
 class Request:
     pass
 
@@ -23,3 +27,26 @@ class ValidRequest(Request):
 
     def __bool__(self):
         return True
+
+
+def validate_request_data_common(
+    fields: List[Field], dict_data: Dict, invalid_req: InvalidRequest
+):
+    for field in fields:
+        if field.name not in dict_data:
+            invalid_req.add_error(
+                parameter="dict_data", message=f"Missing field {field.name}."
+            )
+        elif not isinstance(dict_data[field.name], field.type):
+            invalid_req.add_error(
+                parameter="dict_data",
+                message=f"Field {field.name} expects {field.type} "
+                f"but received {type(dict_data[field.name])}",
+            )
+
+    field_names = set([field.name for field in fields])
+    for key in dict_data:
+        if key not in field_names:
+            invalid_req.add_error(
+                parameter="dict_data", message=f"Invalid field {key}."
+            )

--- a/alchemy/data/request/task_request.py
+++ b/alchemy/data/request/task_request.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass, fields
+from typing import List
+
+from alchemy.data.request.base_request import (
+    ValidRequest,
+    InvalidRequest,
+    validate_request_data_common,
+)
+
+
+@dataclass
+class TaskCreateRequest(ValidRequest):
+    name: str
+    entity_type: str
+    annotators: List
+    labels: List
+    data_files: List
+
+    @classmethod
+    def from_dict(cls, dict_data):
+        invalid_req = InvalidRequest()
+
+        cls._validate_request_data(dict_data, invalid_req)
+
+        if invalid_req.has_errors():
+            return invalid_req
+
+        return cls(**dict_data)
+
+    @classmethod
+    def _validate_request_data(cls, dict_data, invalid_req):
+        data_fields = fields(cls)
+        validate_request_data_common(
+            fields=data_fields, dict_data=dict_data, invalid_req=invalid_req
+        )
+        for field_name in ["annotators", "labels", "data_files"]:
+            if field_name in dict_data:
+                if (
+                    dict_data[field_name] is not None
+                    and len(dict_data[field_name]) == 0
+                ):
+                    invalid_req.add_error(
+                        parameter="dict_data", message=f"Field {field_name} is empty."
+                    )
+                elif dict_data[field_name] is None:
+                    invalid_req.add_error(
+                        parameter="dict_data", message=f"Field {field_name} is None."
+                    )

--- a/alchemy/shared/component.py
+++ b/alchemy/shared/component.py
@@ -1,4 +1,6 @@
 from alchemy.dao.annotation_dao import AnnotationDao
+from alchemy.dao.task_dao import TaskDao
 from alchemy.db.model import db
 
 annotation_dao = AnnotationDao(dbsession=db.session)
+task_dao = TaskDao(dbsession=db.session)

--- a/tests/unit/dao/test_task_dao.py
+++ b/tests/unit/dao/test_task_dao.py
@@ -1,0 +1,145 @@
+from mockito import when
+from sqlalchemy.exc import DBAPIError
+
+from alchemy.dao.task_dao import TaskDao
+from alchemy.data.request.task_request import TaskCreateRequest
+from alchemy.db.model import EntityTypeEnum, Task
+
+entity_type = EntityTypeEnum.COMPANY
+name = "b2c"
+labels = ["hotdog"]
+annotators = ["user1", "user2"]
+data_files = ["file1.txt", "file2.txt"]
+
+
+def _count_task(dbsession):
+    return dbsession.query(Task).count()
+
+
+def test_task_create_success(dbsession):
+    task_dao = TaskDao(dbsession=dbsession)
+    create_request = TaskCreateRequest(
+        name=name,
+        entity_type=entity_type,
+        labels=labels,
+        annotators=annotators,
+        data_files=data_files,
+    )
+
+    task = task_dao.create_task(create_request=create_request)
+
+    num_of_tasks = _count_task(dbsession)
+    assert num_of_tasks == 1
+
+    assert task is not None
+    assert task.name == name
+    assert set(task.get_labels()) == set(labels)
+    assert set(task.get_data_filenames()) == set(data_files)
+    assert set(task.get_annotators()) == set(annotators)
+
+
+def test_task_create_with_invalid_request(dbsession):
+    task_dao = TaskDao(dbsession=dbsession)
+    create_request = TaskCreateRequest.from_dict({"name": name})
+
+    try:
+        _ = task_dao.create_task(create_request=create_request)
+    except Exception as e:
+        assert "Invalid request:" in str(e)
+
+    num_of_tasks = _count_task(dbsession)
+    assert num_of_tasks == 0
+
+
+def test_task_create_with_duplicate_labels(dbsession):
+    label = "healthecare"
+    task1 = Task(name="task1")
+    task1.set_labels([label])
+    task1.set_annotators(annotators)
+    task1.set_entity_type(entity_type)
+    task1.set_data_filenames(data_files)
+    dbsession.add(task1)
+    dbsession.commit()
+
+    task_dao = TaskDao(dbsession=dbsession)
+    create_request = TaskCreateRequest(
+        name=name,
+        entity_type=entity_type,
+        labels=[label, "b2b"],
+        annotators=annotators,
+        data_files=data_files,
+    )
+
+    try:
+        _ = task_dao.create_task(create_request=create_request)
+    except Exception as e:
+        assert f"Label {label} is already created in task {task1.name}" in str(e)
+
+    num_of_tasks = _count_task(dbsession)
+    assert num_of_tasks == 1
+
+    existing_task = dbsession.query(Task).one_or_none()
+
+    assert existing_task.id == task1.id
+
+
+def _prepare_for_retry_testcases(dbsession):
+    task_dao = TaskDao(dbsession=dbsession)
+    create_request = TaskCreateRequest(
+        name=name,
+        entity_type=entity_type,
+        labels=labels,
+        annotators=annotators,
+        data_files=data_files,
+    )
+    error_msg = "Mocked Exception!"
+    database_error = DBAPIError(statement="Mocked statement", params={}, orig=error_msg)
+
+    return task_dao, create_request, database_error
+
+
+def test_create_task_failure_retry_success(dbsession):
+    task_dao, create_request, database_error = _prepare_for_retry_testcases(dbsession)
+
+    when(dbsession).commit().thenRaise(database_error).thenRaise(
+        database_error
+    ).thenReturn(True)
+
+    task_dao.create_task(create_request=create_request)
+
+    num_of_annotations = _count_task(dbsession)
+    assert num_of_annotations == 1
+
+
+def test_upsert_annotation_failure_retry_exceeded(dbsession):
+    task_dao, create_request, database_error = _prepare_for_retry_testcases(dbsession)
+
+    when(dbsession).commit().thenRaise(database_error).thenRaise(
+        database_error
+    ).thenRaise(database_error)
+    try:
+        task_dao.create_task(create_request=create_request)
+    except DBAPIError:
+        pass
+
+    num_of_annotations = _count_task(dbsession)
+    assert num_of_annotations == 0
+
+
+def test_upsert_annotation_failure_non_retriable_error(dbsession, monkeypatch):
+    task_dao, create_request, database_error = _prepare_for_retry_testcases(dbsession)
+
+    error_msg = "Mocked Exception!"
+
+    def mock_commit():
+        raise Exception(error_msg)
+
+    monkeypatch.setattr(dbsession, "commit", mock_commit)
+
+    try:
+        task_dao.create_task(create_request=create_request)
+    except Exception as e:
+        assert str(e) == error_msg
+
+    num_of_annotations = _count_task(dbsession)
+    assert num_of_annotations == 0

--- a/tests/unit/data/request/test_task_request.py
+++ b/tests/unit/data/request/test_task_request.py
@@ -1,0 +1,87 @@
+from dataclasses import asdict, fields
+
+import pytest
+
+from alchemy.data.request.task_request import TaskCreateRequest
+from alchemy.db.model import EntityTypeEnum
+
+
+def test_build_task_create_request_with_valid_data():
+    dict_data = {
+        "name": "testhotdog",
+        "entity_type": EntityTypeEnum.COMPANY,
+        "labels": ["B2C"],
+        "annotators": ["user1", "user2"],
+        "data_files": ["data_file.txt"],
+    }
+
+    create_request = TaskCreateRequest.from_dict(dict_data=dict_data)
+
+    assert asdict(create_request) == dict_data
+    assert bool(create_request) is True
+
+
+def test_build_task_create_request_with_invalid_empty_data():
+    dict_data = {}
+
+    create_request = TaskCreateRequest.from_dict(dict_data=dict_data)
+
+    assert create_request.has_errors()
+
+    assert len(create_request.errors) == len(fields(TaskCreateRequest))
+
+    for field in fields(TaskCreateRequest):
+        assert {
+            "parameter": "dict_data",
+            "message": f"Missing field {field.name}.",
+        } in create_request.errors
+
+    assert bool(create_request) is False
+
+
+def test_build_task_create_request_with_invalid_wrong_type_data():
+    dict_data = {
+        "name": 123,
+        "entity_type": 321,
+        "labels": "B2C",
+        "annotators": "123",
+        "data_files": "234",
+    }
+
+    create_request = TaskCreateRequest.from_dict(dict_data=dict_data)
+
+    assert create_request.has_errors()
+
+    assert len(create_request.errors) == len(fields(TaskCreateRequest))
+
+    for field in fields(TaskCreateRequest):
+        assert {
+            "parameter": "dict_data",
+            "message": f"Field {field.name} expects {field.type} "
+            f"but received {type(dict_data[field.name])}",
+        } in create_request.errors
+
+    assert bool(create_request) is False
+
+
+@pytest.mark.parametrize("list_data,error_type", [([], "empty"), (None, "None")])
+def test_build_task_create_request_with_invalid_empty_list(list_data, error_type):
+    dict_data = {
+        "name": "testhotdog",
+        "entity_type": EntityTypeEnum.COMPANY,
+        "labels": list_data,
+        "annotators": list_data,
+        "data_files": list_data,
+    }
+
+    create_request = TaskCreateRequest.from_dict(dict_data=dict_data)
+
+    assert create_request.has_errors()
+
+    for field_name in ["annotators", "labels", "data_files"]:
+        assert {
+            "parameter": "dict_data",
+            "message": f"Field {field_name} is {error_type}.",
+        } in create_request.errors
+
+    assert bool(create_request) is False


### PR DESCRIPTION
In Alchemy, an annotation task can include multiple labels for annotators to work on. For example, in one task, we ask annotators to annotate companies into either "B2C" or "Machine Learning". 

Labels should not be reused in different tasks. Unfortunately given the current design, label is neither treated as its own table nor a part of a primary key. They are treated as strings in a JSON column. 

As a temporary solution, we are checking the duplicates when creating a task. There will be another PR for this check in task update as well. 