### PR TITLE
Update the sorting of the tasks

### DIFF
--- a/alchemy/admin_server/tasks.py
+++ b/alchemy/admin_server/tasks.py
@@ -79,7 +79,7 @@ bp.before_request(_before_request)
 
 @bp.route("/")
 def index():
-    tasks = db.session.query(Task).order_by(Task.created_at.desc()).all()
+    tasks = db.session.query(Task).order_by(Task.name.asc()).all()
     return render_template("tasks/index.html", tasks=tasks)
 
 


### PR DESCRIPTION
This is a temporary and urgent request to sort the tasks by name instead of the creation time. Ideally this should be refactored into the TaskDao object but we will have to implement that later. 

Verified on the website. Tasks are now reordered by name. `TestML` and `TestMML` were created way before the other two so the sorting is working.
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/45179326/99296783-47dca980-2815-11eb-941f-91bd841e9db7.png">


