### PR TITLE
Prevent duplicate labels during task update. 

### DIFF
--- a/alchemy/admin_server/tasks.py
+++ b/alchemy/admin_server/tasks.py
@@ -499,37 +499,3 @@ def parse_data(form, all_files):
     for fname in data:
         assert fname in all_files, f"Data file '{fname}' does not exist"
     return data
-
-
-def _remove_obsolete_requests_under_task(task, data, annotators, labels, entity_type):
-    if data != task.get_data_filenames()[0]:
-        logging.info(
-            "Prepare to remove all requests under task {} "
-            "since the data file has changed".format(task.id)
-        )
-        delete_requests_under_task(db.session, task.id)
-    elif entity_type != task.get_entity_type():
-        logging.info(
-            "Prepare to remove all requests under task {} "
-            "since the entity type has changed".format(task.id)
-        )
-        delete_requests_for_entity_type_under_task(db.session, task.id, entity_type)
-    else:
-        # Updating the annotators
-        for current_annotator in task.get_annotators():
-            if current_annotator not in annotators:
-                logging.info(
-                    "Prepare to remove requests under user {} for "
-                    "task {}".format(current_annotator, task.id)
-                )
-                delete_requests_for_user_under_task(
-                    db.session, current_annotator, task.id
-                )
-        # Updating the labels
-        for current_label in task.get_labels():
-            if current_label not in labels:
-                logging.info(
-                    "Prepare to remove requests under label {} for "
-                    "task {}".format(current_label, task.id)
-                )
-                delete_requests_for_label_under_task(db.session, current_label, task.id)

--- a/alchemy/admin_server/tasks.py
+++ b/alchemy/admin_server/tasks.py
@@ -262,7 +262,7 @@ def update(id):
 
         update_request = TaskUpdateRequest.from_dict(
             {
-                "id": task.id,
+                "task_id": task.id,
                 "name": name,
                 "data_files": [data],
                 "labels": labels,

--- a/alchemy/dao/task_dao.py
+++ b/alchemy/dao/task_dao.py
@@ -6,6 +6,7 @@ from tenacity import (
     retry,
 )
 
+from alchemy.data.request.task_request import TaskBaseRequest
 from alchemy.db.model import Task
 
 
@@ -25,22 +26,52 @@ class TaskDao:
             #  Request Object.
             raise Exception(f"Invalid request: {create_request.errors}")
 
-        labels = list(set(create_request.labels))
-
-        self._check_duplicate_labels(labels)
-
-        annotators = list(set(create_request.annotators))
         task = Task(name=create_request.name)
-        task.set_labels(labels)
-        task.set_annotators(annotators)
-        task.set_data_filenames(create_request.data_files)
-        task.set_entity_type(create_request.entity_type)
+
+        self._check_duplicate_labels(list(set(create_request.labels)))
+        self._configure_task_common(task, create_request)
 
         self.dbsession.add(task)
         self._commit_to_db()
         return task
 
-    def _check_duplicate_labels(self, new_labels):
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=6),
+        retry=retry_if_exception_type(DBAPIError),
+        reraise=True,
+    )
+    def update_task(self, update_request):
+        if not update_request:
+            # TODO We should consider adding Response Object in pair with the
+            #  Request Object.
+            raise Exception(f"Invalid request: {update_request.errors}")
+
+        task = self.dbsession.query(Task).filter_by(id=update_request.id).one_or_none()
+
+        if not task:
+            raise ValueError(f"Invalid task id: {update_request.id}")
+
+        self._check_duplicate_labels(
+            new_labels=list(set(update_request.labels)), task_id_to_update=task.id
+        )
+
+        self._configure_task_common(task, update_request)
+
+        self.dbsession.add(task)
+        self._commit_to_db()
+        return task
+
+    def _configure_task_common(self, task: Task, request: TaskBaseRequest):
+        labels = list(set(request.labels))
+        annotators = list(set(request.annotators))
+        task.name = request.name
+        task.set_labels(labels)
+        task.set_annotators(annotators)
+        task.set_data_filenames(request.data_files)
+        task.set_entity_type(request.entity_type)
+
+    def _check_duplicate_labels(self, new_labels, task_id_to_update=None):
         """This is a temporary hacky solution to prevent users from creating
         duplicate labels. The proper solution involves a much bigger
         refactoring.
@@ -50,7 +81,15 @@ class TaskDao:
 
         TODO replace this once we have the Market Management System in place.
         """
-        tasks = self.dbsession.query(Task).all()
+        if task_id_to_update:
+            # We should only consider labels in tasks other than the one we are
+            # trying to update in case we want to update the labels of a task from
+            # ["label1"] to ["label1", "label2"]
+            tasks = (
+                self.dbsession.query(Task).filter(Task.id != task_id_to_update).all()
+            )
+        else:
+            tasks = self.dbsession.query(Task).all()
 
         existing_labels = dict()
         for task in tasks:
@@ -65,7 +104,7 @@ class TaskDao:
                     f"in task {existing_labels[new_label]}"
                 )
         if len(error_msgs) > 0:
-            raise Exception(error_msgs)
+            raise ValueError(error_msgs)
 
     def _commit_to_db(self):
         try:

--- a/alchemy/dao/task_dao.py
+++ b/alchemy/dao/task_dao.py
@@ -11,6 +11,7 @@ from tenacity import (
 from alchemy.data.request.task_request import TaskBaseRequest, TaskUpdateRequest
 from alchemy.db.model import (
     Task,
+    # TODO these functions should be moved outside of the model module.
     delete_requests_under_task,
     delete_requests_for_entity_type_under_task,
     delete_requests_for_user_under_task,
@@ -74,7 +75,7 @@ class TaskDao:
             new_labels=list(set(update_request.labels)), task_id_to_update=task.id
         )
 
-        self._remove_obsolete_requests_under_task(update_request)
+        self._remove_obsolete_requests_under_task(update_request, task)
 
         _configure_task_common(task, update_request)
 

--- a/alchemy/dao/task_dao.py
+++ b/alchemy/dao/task_dao.py
@@ -66,7 +66,11 @@ class TaskDao:
             #  Request Object.
             raise Exception(f"Invalid request: {update_request.errors}")
 
-        task = self.dbsession.query(Task).filter_by(id=update_request.id).one_or_none()
+        task = (
+            self.dbsession.query(Task)
+            .filter_by(id=update_request.task_id)
+            .one_or_none()
+        )
 
         if not task:
             raise ValueError(f"Invalid task id: {update_request.id}")

--- a/alchemy/data/request/base_request.py
+++ b/alchemy/data/request/base_request.py
@@ -32,18 +32,8 @@ class ValidRequest(Request):
 def validate_request_data_common(
     fields: List[Field], dict_data: Dict, invalid_req: InvalidRequest
 ):
-    for field in fields:
-        if field.name not in dict_data:
-            invalid_req.add_error(
-                parameter="dict_data", message=f"Missing field {field.name}."
-            )
-        elif not isinstance(dict_data[field.name], field.type):
-            invalid_req.add_error(
-                parameter="dict_data",
-                message=f"Field {field.name} expects {field.type} "
-                f"but received {type(dict_data[field.name])}",
-            )
-
+    check_missing_fields(fields, dict_data, invalid_req)
+    check_invalid_field_type(fields, dict_data, invalid_req)
     check_invalid_request_fields(fields, dict_data, invalid_req)
 
 
@@ -55,4 +45,28 @@ def check_invalid_request_fields(
         if key not in field_names:
             invalid_req.add_error(
                 parameter="dict_data", message=f"Invalid field {key}."
+            )
+
+
+def check_invalid_field_type(
+    fields: List[Field], dict_data: Dict, invalid_req: InvalidRequest
+):
+    for field in fields:
+        if field.name in dict_data and not isinstance(
+            dict_data[field.name], field.type
+        ):
+            invalid_req.add_error(
+                parameter="dict_data",
+                message=f"Field {field.name} expects {field.type} "
+                f"but received {type(dict_data[field.name])}",
+            )
+
+
+def check_missing_fields(
+    fields: List[Field], dict_data: Dict, invalid_req: InvalidRequest
+):
+    for field in fields:
+        if field.name not in dict_data:
+            invalid_req.add_error(
+                parameter="dict_data", message=f"Missing field {field.name}."
             )

--- a/alchemy/data/request/base_request.py
+++ b/alchemy/data/request/base_request.py
@@ -44,6 +44,12 @@ def validate_request_data_common(
                 f"but received {type(dict_data[field.name])}",
             )
 
+    check_invalid_request_fields(fields, dict_data, invalid_req)
+
+
+def check_invalid_request_fields(
+    fields: List[Field], dict_data: Dict, invalid_req: InvalidRequest
+):
     field_names = set([field.name for field in fields])
     for key in dict_data:
         if key not in field_names:

--- a/alchemy/data/request/task_request.py
+++ b/alchemy/data/request/task_request.py
@@ -57,7 +57,7 @@ class TaskCreateRequest(TaskBaseRequest):
 
 @dataclass
 class TaskUpdateRequest(TaskBaseRequest):
-    id: int
+    task_id: int
 
     @classmethod
     def _validate_request_data(cls, dict_data, invalid_req):

--- a/alchemy/data/request/task_request.py
+++ b/alchemy/data/request/task_request.py
@@ -6,6 +6,7 @@ from alchemy.data.request.base_request import (
     InvalidRequest,
     validate_request_data_common,
     check_invalid_request_fields,
+    check_invalid_field_type,
 )
 
 
@@ -60,21 +61,6 @@ class TaskUpdateRequest(TaskBaseRequest):
 
     @classmethod
     def _validate_request_data(cls, dict_data, invalid_req):
-        valid_fields = []
-        for field in fields(cls):
-            if field.name in dict_data and isinstance(
-                dict_data[field.name], field.type
-            ):
-                valid_fields.append(field.name)
-
-        if "id" not in valid_fields:
-            invalid_req.add_error(
-                parameter="dict_data", message=f"Missing valid task id in the request."
-            )
-        elif len(valid_fields) < 2:
-            invalid_req.add_error(
-                parameter="dict_data",
-                message=f"Missing valid field(s) to update in the request.",
-            )
-
-        check_invalid_request_fields(fields(cls), dict_data, invalid_req)
+        super()._validate_request_data(dict_data, invalid_req)
+        if not invalid_req.has_errors():
+            _check_task_fields_common(dict_data, invalid_req)

--- a/alchemy/data/request/task_request.py
+++ b/alchemy/data/request/task_request.py
@@ -8,8 +8,21 @@ from alchemy.data.request.base_request import (
 )
 
 
+def _check_task_fields_common(dict_data, invalid_req):
+    for field_name in ["entity_type", "annotators", "labels", "data_files"]:
+        if field_name in dict_data:
+            if dict_data[field_name] is not None and len(dict_data[field_name]) == 0:
+                invalid_req.add_error(
+                    parameter="dict_data", message=f"Field {field_name} is empty."
+                )
+            elif dict_data[field_name] is None:
+                invalid_req.add_error(
+                    parameter="dict_data", message=f"Field {field_name} is None."
+                )
+
+
 @dataclass
-class TaskCreateRequest(ValidRequest):
+class TaskBaseRequest(ValidRequest):
     name: str
     entity_type: str
     annotators: List
@@ -33,16 +46,21 @@ class TaskCreateRequest(ValidRequest):
         validate_request_data_common(
             fields=data_fields, dict_data=dict_data, invalid_req=invalid_req
         )
-        for field_name in ["annotators", "labels", "data_files"]:
-            if field_name in dict_data:
-                if (
-                    dict_data[field_name] is not None
-                    and len(dict_data[field_name]) == 0
-                ):
-                    invalid_req.add_error(
-                        parameter="dict_data", message=f"Field {field_name} is empty."
-                    )
-                elif dict_data[field_name] is None:
-                    invalid_req.add_error(
-                        parameter="dict_data", message=f"Field {field_name} is None."
-                    )
+
+
+@dataclass
+class TaskCreateRequest(TaskBaseRequest):
+    @classmethod
+    def _validate_request_data(cls, dict_data, invalid_req):
+        super()._validate_request_data(dict_data, invalid_req)
+        _check_task_fields_common(dict_data, invalid_req)
+
+
+@dataclass
+class TaskUpdateRequest(TaskBaseRequest):
+    id: int
+
+    @classmethod
+    def _validate_request_data(cls, dict_data, invalid_req):
+        super()._validate_request_data(dict_data, invalid_req)
+        _check_task_fields_common(dict_data, invalid_req)

--- a/alchemy/data/request/task_request.py
+++ b/alchemy/data/request/task_request.py
@@ -15,10 +15,6 @@ def _check_task_fields_common(dict_data, invalid_req):
                 invalid_req.add_error(
                     parameter="dict_data", message=f"Field {field_name} is empty."
                 )
-            elif dict_data[field_name] is None:
-                invalid_req.add_error(
-                    parameter="dict_data", message=f"Field {field_name} is None."
-                )
 
 
 @dataclass
@@ -53,7 +49,8 @@ class TaskCreateRequest(TaskBaseRequest):
     @classmethod
     def _validate_request_data(cls, dict_data, invalid_req):
         super()._validate_request_data(dict_data, invalid_req)
-        _check_task_fields_common(dict_data, invalid_req)
+        if not invalid_req.has_errors():
+            _check_task_fields_common(dict_data, invalid_req)
 
 
 @dataclass
@@ -62,5 +59,7 @@ class TaskUpdateRequest(TaskBaseRequest):
 
     @classmethod
     def _validate_request_data(cls, dict_data, invalid_req):
+        # TODO we only need to have id and at least another field.
         super()._validate_request_data(dict_data, invalid_req)
-        _check_task_fields_common(dict_data, invalid_req)
+        if not invalid_req.has_errors():
+            _check_task_fields_common(dict_data, invalid_req)

--- a/tests/unit/data/request/test_task_request.py
+++ b/tests/unit/data/request/test_task_request.py
@@ -21,7 +21,7 @@ from alchemy.db.model import EntityTypeEnum
         ),
         (
             {
-                "id": 1,
+                "task_id": 1,
                 "name": "testhotdog",
                 "entity_type": EntityTypeEnum.COMPANY,
                 "labels": ["B2C"],
@@ -75,7 +75,7 @@ def test_build_task_request_with_invalid_empty_data(dict_data, request_class):
         ),
         (
             {
-                "id": "Sdf",
+                "task_id": "Sdf",
                 "name": 123,
                 "entity_type": 321,
                 "labels": "B2C",
@@ -118,7 +118,7 @@ def test_build_task_request_with_invalid_wrong_type_data(dict_data, request_clas
         ),
         (
             {
-                "id": 1,
+                "task_id": 1,
                 "name": "testhotdog",
                 "entity_type": EntityTypeEnum.COMPANY,
                 "labels": [],

--- a/tests/unit/data/request/test_task_request.py
+++ b/tests/unit/data/request/test_task_request.py
@@ -6,82 +6,138 @@ from alchemy.data.request.task_request import TaskCreateRequest, TaskUpdateReque
 from alchemy.db.model import EntityTypeEnum
 
 
-def test_build_task_create_request_with_valid_data():
-    dict_data = {
-        "name": "testhotdog",
-        "entity_type": EntityTypeEnum.COMPANY,
-        "labels": ["B2C"],
-        "annotators": ["user1", "user2"],
-        "data_files": ["data_file.txt"],
-    }
+@pytest.mark.parametrize(
+    "dict_data,request_class",
+    [
+        (
+            {
+                "name": "testhotdog",
+                "entity_type": EntityTypeEnum.COMPANY,
+                "labels": ["B2C"],
+                "annotators": ["user1", "user2"],
+                "data_files": ["data_file.txt"],
+            },
+            TaskCreateRequest,
+        ),
+        (
+            {
+                "id": 1,
+                "name": "testhotdog",
+                "entity_type": EntityTypeEnum.COMPANY,
+                "labels": ["B2C"],
+                "annotators": ["user1", "user2"],
+                "data_files": ["data_file.txt"],
+            },
+            TaskUpdateRequest,
+        ),
+    ],
+)
+def test_build_task_request_with_valid_data(dict_data, request_class):
 
-    create_request = TaskCreateRequest.from_dict(dict_data=dict_data)
+    request = request_class.from_dict(dict_data=dict_data)
 
-    assert asdict(create_request) == dict_data
-    assert bool(create_request) is True
+    assert asdict(request) == dict_data
+    assert bool(request) is True
 
 
-def test_build_task_create_request_with_invalid_empty_data():
-    dict_data = {}
+@pytest.mark.parametrize(
+    "dict_data,request_class", [({}, TaskCreateRequest), ({}, TaskUpdateRequest)]
+)
+def test_build_task_request_with_invalid_empty_data(dict_data, request_class):
 
-    create_request = TaskCreateRequest.from_dict(dict_data=dict_data)
+    request = request_class.from_dict(dict_data=dict_data)
 
-    assert create_request.has_errors()
+    assert request.has_errors()
 
-    assert len(create_request.errors) == len(fields(TaskCreateRequest))
+    assert len(request.errors) == len(fields(request_class))
 
-    for field in fields(TaskCreateRequest):
+    for field in fields(request_class):
         assert {
             "parameter": "dict_data",
             "message": f"Missing field {field.name}.",
-        } in create_request.errors
+        } in request.errors
 
-    assert bool(create_request) is False
+    assert bool(request) is False
 
 
-def test_build_task_create_request_with_invalid_wrong_type_data():
-    dict_data = {
-        "name": 123,
-        "entity_type": 321,
-        "labels": "B2C",
-        "annotators": "123",
-        "data_files": "234",
-    }
+@pytest.mark.parametrize(
+    "dict_data,request_class",
+    [
+        (
+            {
+                "name": 123,
+                "entity_type": 321,
+                "labels": "B2C",
+                "annotators": "123",
+                "data_files": "234",
+            },
+            TaskCreateRequest,
+        ),
+        (
+            {
+                "id": "Sdf",
+                "name": 123,
+                "entity_type": 321,
+                "labels": "B2C",
+                "annotators": "123",
+                "data_files": "234",
+            },
+            TaskUpdateRequest,
+        ),
+    ],
+)
+def test_build_task_request_with_invalid_wrong_type_data(dict_data, request_class):
+    request = request_class.from_dict(dict_data=dict_data)
 
-    create_request = TaskCreateRequest.from_dict(dict_data=dict_data)
+    assert request.has_errors()
 
-    assert create_request.has_errors()
+    assert len(request.errors) == len(fields(request_class))
 
-    assert len(create_request.errors) == len(fields(TaskCreateRequest))
-
-    for field in fields(TaskCreateRequest):
+    for field in fields(request_class):
         assert {
             "parameter": "dict_data",
             "message": f"Field {field.name} expects {field.type} "
             f"but received {type(dict_data[field.name])}",
-        } in create_request.errors
+        } in request.errors
 
-    assert bool(create_request) is False
+    assert bool(request) is False
 
 
-@pytest.mark.parametrize("list_data,error_type", [([], "empty")])
-def test_build_task_create_request_with_invalid_empty_list(list_data, error_type):
-    dict_data = {
-        "name": "testhotdog",
-        "entity_type": EntityTypeEnum.COMPANY,
-        "labels": list_data,
-        "annotators": list_data,
-        "data_files": list_data,
-    }
+@pytest.mark.parametrize(
+    "dict_data,request_class",
+    [
+        (
+            {
+                "name": "testhotdog",
+                "entity_type": EntityTypeEnum.COMPANY,
+                "labels": [],
+                "annotators": [],
+                "data_files": [],
+            },
+            TaskCreateRequest,
+        ),
+        (
+            {
+                "id": 1,
+                "name": "testhotdog",
+                "entity_type": EntityTypeEnum.COMPANY,
+                "labels": [],
+                "annotators": [],
+                "data_files": [],
+            },
+            TaskUpdateRequest,
+        ),
+    ],
+)
+def test_build_task_request_with_invalid_empty_list(dict_data, request_class):
+    request = request_class.from_dict(dict_data=dict_data)
 
-    create_request = TaskCreateRequest.from_dict(dict_data=dict_data)
-
-    assert create_request.has_errors()
+    assert request.has_errors()
 
     for field_name in ["annotators", "labels", "data_files"]:
         assert {
             "parameter": "dict_data",
-            "message": f"Field {field_name} is {error_type}.",
-        } in create_request.errors
+            "message": f"Field {field_name} is empty.",
+        } in request.errors
 
-    assert bool(create_request) is False
+    assert bool(request) is False

--- a/tests/unit/data/request/test_task_request.py
+++ b/tests/unit/data/request/test_task_request.py
@@ -2,7 +2,7 @@ from dataclasses import asdict, fields
 
 import pytest
 
-from alchemy.data.request.task_request import TaskCreateRequest
+from alchemy.data.request.task_request import TaskCreateRequest, TaskUpdateRequest
 from alchemy.db.model import EntityTypeEnum
 
 
@@ -64,7 +64,7 @@ def test_build_task_create_request_with_invalid_wrong_type_data():
     assert bool(create_request) is False
 
 
-@pytest.mark.parametrize("list_data,error_type", [([], "empty"), (None, "None")])
+@pytest.mark.parametrize("list_data,error_type", [([], "empty")])
 def test_build_task_create_request_with_invalid_empty_list(list_data, error_type):
     dict_data = {
         "name": "testhotdog",


### PR DESCRIPTION
This is a follow up PR for preventing duplicate labels in Alchemy tasks. The user can update the tasks with a new set of labels and we need to make sure no duplicate labels are included, just like what we did when creating a new task.

The `TaskUpdateRequest` Object is pretty much the same as the `TaskCreateRequest` Object. This is because the update requests only come from a form on the website so all the fields are included when submitting. We could make it more flexible to accept partial fields to update, but it makes the validation process more complicated. Given the current usecase, I would postpone that unless there are new usecases showing up.

There are legacy code to be refactored (for example, `_remove_obsolete_requests_under_task`) so I put TODO there. It's out of scope for this bug fix. 

 