### PR TITLE
Let's encrypt SSL

### DIFF
--- a/.conf/nginx/alchemy.impact.georgianpartners.com.conf.template
+++ b/.conf/nginx/alchemy.impact.georgianpartners.com.conf.template
@@ -12,6 +12,7 @@ server {
 
     location ^~ /.well-known/acme-challenge/ {
       default_type "text/plain";
+      autoindex off;
       root /var/www/letsencrypt;
     }
 

--- a/.conf/nginx/alchemy.impact.georgianpartners.com.conf.template
+++ b/.conf/nginx/alchemy.impact.georgianpartners.com.conf.template
@@ -8,8 +8,26 @@ upstream admin_server_us {
 
 server {
     listen 80;
-
     server_name ${DOMAIN_NAME};
+
+    location ^~ /.well-known/acme-challenge/ {
+      default_type "text/plain";
+      root /var/www/letsencrypt;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name ${DOMAIN_NAME};
+
+    ssl_certificate     /etc/letsencrypt/live/${CERT_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${CERT_NAME}/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
 
     location /admin/ {
         rewrite /admin/(.*) /$1  break;

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -79,6 +79,8 @@ services:
     image: nginx:stable-alpine
     volumes:
       - .conf/nginx:/etc/nginx/templates
+      - /etc/letsencrypt/challenge:/var/www/letsencrypt
+      - /etc/letsencrypt:/etc/letsencrypt
     depends_on:
       - admin_server
       - annotation_server
@@ -87,6 +89,7 @@ services:
       - annotation_server
     ports:
     - "80:80"
+    - "443:443"
 
   redis:
     image: "redis:alpine"


### PR DESCRIPTION
I've got the certificates for both staging and production and tested these configs on staging server [https://tube.alchemy.impact.georgian.io/](https://tube.alchemy.impact.georgian.io/).

It's blocking the Okta integration, so I prefer not to wait for @jzhang-gp and I'm asking you for a review. Thanks! 