### PR TITLE
Test coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,9 @@ jobs:
         echo "ALCHEMY_FILESTORE_DIR=\"$RUNNER_TEMP/__filestore\"" >> $GITHUB_ENV
         echo "SECRET_KEY=randomsecretkeytopreventerrors" >> $GITHUB_ENV
     - name: Run tests
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        COVERAGE: 1
       run: |
         export TEST_ARGS="--basetemp=$RUNNER_TEMP"
         sh ci/run_tests.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,8 @@ jobs:
         echo Installing test requirements
         pip install -r requirements/test.txt
         sh ci/install_deps.sh --no-gcp --no-spacy
-
+    - name: Set up environment
+      run: |
         ALCHEMY_FILESTORE_DIR="$RUNNER_TEMP/__filestore"
         mkdir -p "$ALCHEMY_FILESTORE_DIR"
 
@@ -31,9 +32,15 @@ jobs:
         echo "SECRET_KEY=randomsecretkeytopreventerrors" >> $GITHUB_ENV
     - name: Run tests
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         COVERAGE: 1
       run: |
         export TEST_ARGS="--basetemp=$RUNNER_TEMP"
         sh ci/run_tests.sh
-
+    - name: Upload coverage info
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ${{ runner.temp }}/coverage/test_coverage.xml
+        directory: ./alchemy
+        verbose: false
+        fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![CI](https://github.com/georgianpartners/annotation_tool/workflows/CI/badge.svg)
+[![codecov](https://codecov.io/gh/georgianpartners/annotation_tool/branch/master/graph/badge.svg?token=DR90HIIVYF)](https://codecov.io/gh/georgianpartners/annotation_tool)
 
 # Getting Started
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,11 +1,21 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 tests_list=$@
 if [ -z $tests_list ]; then
   tests_list='tests'
 fi
 
-PYTEST_CMD="pytest --durations=30 $TEST_ARGS $tests_list"
+if [ "$COVERAGE" ]; then
+  if [ -z $RUNNER_TEMP ]; then
+    export RUNNER_TEMP=/tmp
+  fi
+  mkdir -p $RUNNER_TEMP/coverage
+  COVERAGE_FNAME="$RUNNER_TEMP/coverage/test_coverage.xml"
+  COVERAGE="-s --cov=alchemy --cov-report=xml:$COVERAGE_FNAME"
+fi
+
+PYTEST_CMD="pytest --durations=30 $TEST_ARGS $COVERAGE $tests_list"
 
 echo $PYTEST_CMD
 sh -c "$PYTEST_CMD"
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,5 @@
 flask-oidc>=1.4.0
 pysaml2==6.3.1
 
+# Code coverage
+pytest-cov==2.10.1


### PR DESCRIPTION
codecov token is stored on GitHub repository secrets (for GitHub actions) + google cloud secret manager (for cloud build).

To test cloud build:
```python
gcloud builds submit --substitutions=SHORT_SHA=$(git rev-parse --short $(git log -1 --pretty=format:%h)),BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD),COMMIT_SHA=$(git rev-parse $(git log -1 --pretty=format:%h)),_TARGET=test .
```

Clickup: SA-1523
