### PR TITLE
Put the config line back in the nginx service in docker-compose

### DIFF
--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -78,6 +78,7 @@ services:
       - ADMIN_SERVER_UWSGI=admin_server:5000
     image: nginx:stable-alpine
     volumes:
+      - .conf/nginx:/etc/nginx/templates
       - /etc/letsencrypt/challenge:/var/www/letsencrypt
       - /etc/letsencrypt:/etc/letsencrypt
     depends_on:


### PR DESCRIPTION
This line was deleted by mistake in #189 reverting that change.