### PR TITLE
Consolidated annotations view

### DIFF
--- a/alchemy/sql/consolidated_annotation_view.sql
+++ b/alchemy/sql/consolidated_annotation_view.sql
@@ -30,7 +30,7 @@ select distinct on (ca.entity_type, ca.entity, ca."label")
 	wa_row_num.weight,
 	wa_row_num.entity_type,
 	wa_row_num."label",
-	ca.context->'text' as company_description
+	ca.context->>'text' as company_description
 from weighted_annotation_with_row_number as wa_row_num
 join classification_annotation ca
 on wa_row_num.entity = ca.entity and wa_row_num.entity_type = ca.entity_type and wa_row_num."label" = ca."label" 

--- a/alchemy/sql/consolidated_annotation_view.sql
+++ b/alchemy/sql/consolidated_annotation_view.sql
@@ -1,0 +1,37 @@
+create view consolidated_annotation
+as
+with
+weighted_annotation as
+(select
+	ca.entity,
+	ca.value,
+	ca.entity_type,
+	ca."label",
+	sum(coalesce(ca.weight, 1)) as weight
+	from classification_annotation ca
+	where ca.value != -2 and ca.value != 0
+	group by ca.entity_type, ca.entity, ca."label", ca.value),
+weighted_annotation_with_row_number as
+(select
+	wa.entity,
+	wa.value,
+	wa.entity_type,
+	wa."label",
+	wa.weight,
+	row_number() over (partition by
+							wa.entity_type,
+							wa.entity,
+							wa."label"
+						order by wa.weight desc) as row_num
+	from weighted_annotation as wa)
+select distinct on (ca.entity_type, ca.entity, ca."label")
+	wa_row_num.entity,
+	wa_row_num.value,
+	wa_row_num.weight,
+	wa_row_num.entity_type,
+	wa_row_num."label",
+	ca.context->'text' as company_description
+from weighted_annotation_with_row_number as wa_row_num
+join classification_annotation ca
+on wa_row_num.entity = ca.entity and wa_row_num.entity_type = ca.entity_type and wa_row_num."label" = ca."label" 
+where wa_row_num.row_num = 1

--- a/alchemy/sql/consolidated_annotation_view.sql
+++ b/alchemy/sql/consolidated_annotation_view.sql
@@ -1,37 +1,15 @@
-create view consolidated_annotation
+create or replace view consolidated_annotation
 as
 with
-weighted_annotation as
-(select
-	ca.entity,
-	ca.value,
-	ca.entity_type,
-	ca."label",
-	sum(coalesce(ca.weight, 1)) as weight
+weighted_annotation as (
+	select
+		ca.entity_type
+		,ca.entity
+		,ca.label
+		,sum(coalesce(ca.weight, 1) * ca.value) as weighted_sum
+		,count(1) as total_votes
 	from classification_annotation ca
-	where ca.value != -2 and ca.value != 0
-	group by ca.entity_type, ca.entity, ca."label", ca.value),
-weighted_annotation_with_row_number as
-(select
-	wa.entity,
-	wa.value,
-	wa.entity_type,
-	wa."label",
-	wa.weight,
-	row_number() over (partition by
-							wa.entity_type,
-							wa.entity,
-							wa."label"
-						order by wa.weight desc) as row_num
-	from weighted_annotation as wa)
-select distinct on (ca.entity_type, ca.entity, ca."label")
-	wa_row_num.entity,
-	wa_row_num.value,
-	wa_row_num.weight,
-	wa_row_num.entity_type,
-	wa_row_num."label",
-	ca.context->>'text' as company_description
-from weighted_annotation_with_row_number as wa_row_num
-join classification_annotation ca
-on wa_row_num.entity = ca.entity and wa_row_num.entity_type = ca.entity_type and wa_row_num."label" = ca."label" 
-where wa_row_num.row_num = 1
+	where ca.value in (-1,1)
+	group by ca.entity_type, ca.entity, ca.label
+)
+select * from weighted_annotation


### PR DESCRIPTION
This sql query creates a table view of the consolidated annotations using the majority vote mechanism. It includes the following columns:

- Entity type
- Entity
- Label
- Value of the majority vote
- Weight of the majority vote
- Company description

If we don't need the company description in the view, the performance of the view would be faster. The distinct on and join slows things down. 

For the hybrid output purpose, it may not be necessary to the description in this view. The description comes from pitchbook, which is already available in Data Platform. 

I created a view called `temp_consolidated_annotations`. We can use that to check if the view works for you.