### PR TITLE
SA-3066 Change the dependency installation process and fix some typos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          wget \
          curl \
          git \
-         xmlsec1 && \
-     rm -rf /var/lib/apt/lists/*
+         xmlsec1
 # xmlsec1: for SAML
 
 WORKDIR /base
@@ -62,15 +61,10 @@ RUN set -ex \
     && deps=' \
         libexpat1 \
     ' \
-    && apt-get update && apt-get install -y $buildDeps $deps --no-install-recommends  && rm -rf /var/lib/apt/lists/* \
+    && apt-get install -y $buildDeps $deps --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache -r requirements/production.txt \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && find /usr/local -depth \
-    \( \
-        \( -type d -a -name test -o -name tests \) \
-        -o \
-        \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-    \) -exec rm -rf '{}' +
+    && apt-get purge -y --auto-remove $buildDeps
 
 FROM production as staging
 # It's the same as production. At least for now.

--- a/ci/run_server.sh
+++ b/ci/run_server.sh
@@ -10,16 +10,16 @@ while test $# -gt 0; do
   case "$1" in
     -h|--help)
       echo "This is a script to launch alchemy server in development and production."
-      echo "USGAGE:"
+      echo "USAGE:"
       echo "  $0 [OPTIONS] (admin_server|annotation_server)"
       echo "  "
       echo "OPTIONS:"
       echo -e "  --flask-env (development|production|...)"
-      echo -e "                        \t Overrides FLASK_ENV"
-      echo -e "  --flask-host ip       \t Overrides FLASK_RUN_HOST"
-      echo -e "  --flask-port port,    \t Overrides FLASK_RUN_PORT"
+      echo -e "                         \t Overrides FLASK_ENV"
+      echo -e "  --flask-host ip        \t Overrides FLASK_RUN_HOST"
+      echo -e "  --flask-port port,     \t Overrides FLASK_RUN_PORT"
       echo -e "    -p port"
-      echo -e "  --database databse_uri\t Overrides ALCHEMY_DATABASE_URI"
+      echo -e "  --database database_uri\t Overrides ALCHEMY_DATABASE_URI"
       exit 0
       ;;
     --flask-env)


### PR DESCRIPTION
* Cleaning the apt cache is now postponed to creating the production images, it has two benefits:
  - It's easier to install new packages for debugging in the local development image (such as vim, ps, pkill, etc)
  - Removed the need for an extra `apt update` when installing production dependencies, making the build ~15-20 seconds faster.
* Removed the command that deletes *.pyc files. They are going to be recreated on the first run, so it makes the cold start a bit faster
* Two typos are fixed